### PR TITLE
chore: fix Homebrew installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           DOTFILES_DIR=$GITHUB_WORKSPACE \
+          NONINTERACTIVE=1 \
           HOMEBREW_BUNDLE_CASK_SKIP="${{ needs.get-cask-packages.outputs.packages }}" \
           sh scripts/install.sh
   check:
@@ -36,6 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           DOTFILES_DIR=$GITHUB_WORKSPACE \
+          NONINTERACTIVE=1 \
           HOMEBREW_BUNDLE_CASK_SKIP="${{ needs.get-cask-packages.outputs.packages }}" \
           sh scripts/install.sh
       - run: editorconfig-checker
@@ -47,6 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           DOTFILES_DIR=$GITHUB_WORKSPACE \
+          NONINTERACTIVE=1 \
           HOMEBREW_BUNDLE_CASK_SKIP="${{ needs.get-cask-packages.outputs.packages }}" \
           sh scripts/install.sh
       - run: sh scripts/install.test.sh

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -59,7 +59,7 @@ fi
 if ! type brew &>/dev/null; then
   log_info "Installing Homebrew..."
 
-  NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
   log_success "Successfully installed Homebrew."
 else


### PR DESCRIPTION
An error occurs when installing Homebrew with the `NONINTERACTIVE` environment variable set.

```
==> Running in non-interactive mode because `$NONINTERACTIVE` is set.
==> Checking for `sudo` access (which may request your password)...
Need sudo access on macOS (e.g. the user p-chan needs to be an Administrator)!
```

So, remove `NONINTERACTIVE` environment variable and add `NONINTERACTIVE` environment variable to only GitHub Actions.