### PR TITLE
ci: add PR title check for Angular-flavored Conventional Commits

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,17 @@
+name: Check PR Title
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Check PR Title
+        run: |
+          deno run -A scripts/check-pr-title.ts "${{ github.event.pull_request.title }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,4 @@ jobs:
           HOMEBREW_BUNDLE_CASK_SKIP="${{ needs.get-cask-packages.outputs.packages }}" \
           sh scripts/install.sh
       - run: sh scripts/install.test.sh
+      - run: deno test -A scripts/

--- a/scripts/check-pr-title.test.ts
+++ b/scripts/check-pr-title.test.ts
@@ -2,7 +2,7 @@ import { assertEquals } from "jsr:@std/assert@1.0.13";
 import { checkTitle } from "./check-pr-title.ts";
 
 async function runCLI(
-  args: string[]
+  args: string[],
 ): Promise<{ code: number; stdout: string; stderr: string }> {
   const cmd = new Deno.Command("deno", {
     args: ["run", "-A", "scripts/check-pr-title.ts", ...args],
@@ -11,11 +11,11 @@ async function runCLI(
   });
 
   const { code, stdout, stderr } = await cmd.output();
-  
-  return { 
-    code, 
+
+  return {
+    code,
     stdout: new TextDecoder().decode(stdout),
-    stderr: new TextDecoder().decode(stderr)
+    stderr: new TextDecoder().decode(stderr),
   };
 }
 
@@ -44,7 +44,7 @@ Deno.test(
         assertEquals(result.valid, true, `Expected "${title}" to be valid`);
       });
     }
-  }
+  },
 );
 
 Deno.test("Invalid PR titles", async (t) => {
@@ -106,7 +106,7 @@ Deno.test("Invalid PR titles", async (t) => {
         assertEquals(
           result.error,
           expectedError,
-          `Expected specific error for "${title}"`
+          `Expected specific error for "${title}"`,
         );
       }
     });
@@ -161,7 +161,7 @@ Deno.test("Scope variations", async (t) => {
     if (!result.valid) {
       assertEquals(
         result.error,
-        "Error: PR title does not conform to Angular-flavored Conventional Commits-like format"
+        "Error: PR title does not conform to Angular-flavored Conventional Commits-like format",
       );
     }
   });
@@ -174,9 +174,9 @@ Deno.test("CLI Integration Tests", async (t) => {
     assertEquals(code, 0);
     assertEquals(
       stdout.includes(
-        "PR title conforms to Angular-flavored Conventional Commits-like format"
+        "PR title conforms to Angular-flavored Conventional Commits-like format",
       ),
-      true
+      true,
     );
     assertEquals(stderr.trim(), "");
   });

--- a/scripts/check-pr-title.test.ts
+++ b/scripts/check-pr-title.test.ts
@@ -71,6 +71,11 @@ Deno.test("Invalid PR titles", async (t) => {
         "Error: PR title does not conform to Angular-flavored Conventional Commits-like format",
     },
     {
+      title: "feat:  ",
+      expectedError:
+        "Error: PR title does not conform to Angular-flavored Conventional Commits-like format",
+    },
+    {
       title: "unknown: some change",
       expectedError:
         "Error: PR title does not conform to Angular-flavored Conventional Commits-like format",

--- a/scripts/check-pr-title.test.ts
+++ b/scripts/check-pr-title.test.ts
@@ -1,0 +1,211 @@
+import { assertEquals } from "jsr:@std/assert@1.0.13";
+import { checkTitle } from "./check-pr-title.ts";
+
+async function runCLI(
+  args: string[]
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const cmd = new Deno.Command("deno", {
+    args: ["run", "-A", "scripts/check-pr-title.ts", ...args],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const { code, stdout, stderr } = await cmd.output();
+  
+  return { 
+    code, 
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr)
+  };
+}
+
+Deno.test(
+  "Valid Angular-flavored Conventional Commits titles",
+  async (t) => {
+    const validTitles = [
+      "feat: add new feature",
+      "fix: resolve bug",
+      "docs: update readme",
+      "style: format code",
+      "refactor: improve performance",
+      "test: add unit tests",
+      "build: update dependencies",
+      "ci: add workflow",
+      "perf: optimize algorithm",
+      "feat(router): add lazy loading",
+      "fix(auth): handle token expiry",
+      "docs(api): update endpoints",
+    ];
+
+    for (const title of validTitles) {
+      await t.step(`"${title}" should be valid`, () => {
+        const result = checkTitle(title);
+
+        assertEquals(result.valid, true, `Expected "${title}" to be valid`);
+      });
+    }
+  }
+);
+
+Deno.test("Invalid PR titles", async (t) => {
+  const invalidTitles = [
+    { title: "", expectedError: "Error: PR title is empty" },
+    {
+      title: "invalid: bad type",
+      expectedError:
+        "Error: PR title does not conform to Angular-flavored Conventional Commits-like format",
+    },
+    {
+      title: "Add new feature",
+      expectedError:
+        "Error: PR title does not conform to Angular-flavored Conventional Commits-like format",
+    },
+    {
+      title: "feat:",
+      expectedError:
+        "Error: PR title does not conform to Angular-flavored Conventional Commits-like format",
+    },
+    {
+      title: "feat: ",
+      expectedError:
+        "Error: PR title does not conform to Angular-flavored Conventional Commits-like format",
+    },
+    {
+      title: "unknown: some change",
+      expectedError:
+        "Error: PR title does not conform to Angular-flavored Conventional Commits-like format",
+    },
+    {
+      title: "feat add new feature",
+      expectedError:
+        "Error: PR title does not conform to Angular-flavored Conventional Commits-like format",
+    },
+    {
+      title: "feat()",
+      expectedError:
+        "Error: PR title does not conform to Angular-flavored Conventional Commits-like format",
+    },
+    {
+      title: "FEAT: uppercase type",
+      expectedError:
+        "Error: PR title does not conform to Angular-flavored Conventional Commits-like format",
+    },
+  ];
+
+  for (const { title, expectedError } of invalidTitles) {
+    await t.step(`"${title}" should be invalid`, () => {
+      const result = checkTitle(title);
+
+      assertEquals(result.valid, false, `Expected "${title}" to be invalid`);
+      if (!result.valid) {
+        assertEquals(
+          result.error,
+          expectedError,
+          `Expected specific error for "${title}"`
+        );
+      }
+    });
+  }
+});
+
+Deno.test("Angular types are supported", async (t) => {
+  const angularTypes = [
+    "build",
+    "ci",
+    "docs",
+    "feat",
+    "fix",
+    "perf",
+    "refactor",
+    "style",
+    "test",
+  ];
+
+  for (const type of angularTypes) {
+    await t.step(`Type "${type}" should be supported`, () => {
+      const result = checkTitle(`${type}: test change`);
+
+      assertEquals(result.valid, true, `Type "${type}" should be valid`);
+    });
+  }
+});
+
+Deno.test("Scope variations", async (t) => {
+  await t.step("No scope should be valid", () => {
+    const result = checkTitle("feat: add feature");
+
+    assertEquals(result.valid, true);
+  });
+
+  await t.step("Single word scope should be valid", () => {
+    const result = checkTitle("feat(auth): add feature");
+
+    assertEquals(result.valid, true);
+  });
+
+  await t.step("Multi-word scope should be valid", () => {
+    const result = checkTitle("feat(user-auth): add feature");
+
+    assertEquals(result.valid, true);
+  });
+
+  await t.step("Empty scope should be invalid", () => {
+    const result = checkTitle("feat(): add feature");
+
+    assertEquals(result.valid, false);
+    if (!result.valid) {
+      assertEquals(
+        result.error,
+        "Error: PR title does not conform to Angular-flavored Conventional Commits-like format"
+      );
+    }
+  });
+});
+
+Deno.test("CLI Integration Tests", async (t) => {
+  await t.step("Valid title should exit with code 0", async () => {
+    const { code, stdout, stderr } = await runCLI(["feat: add new feature"]);
+
+    assertEquals(code, 0);
+    assertEquals(
+      stdout.includes(
+        "PR title conforms to Angular-flavored Conventional Commits-like format"
+      ),
+      true
+    );
+    assertEquals(stderr.trim(), "");
+  });
+
+  await t.step("Invalid title should exit with code 1", async () => {
+    const { code, stdout, stderr } = await runCLI(["invalid title"]);
+
+    assertEquals(code, 1);
+    assertEquals(stderr.includes("Error:"), true);
+    assertEquals(stdout.trim(), "");
+  });
+
+  await t.step("No arguments should exit with code 1", async () => {
+    const { code, stdout, stderr } = await runCLI([]);
+
+    assertEquals(code, 1);
+    assertEquals(stderr.includes("Error: PR title is not specified"), true);
+    assertEquals(stdout.trim(), "");
+  });
+
+  await t.step("--help should exit with code 0", async () => {
+    const { code, stdout, stderr } = await runCLI(["--help"]);
+
+    assertEquals(code, 0);
+    assertEquals(stdout.includes("Usage:"), true);
+    assertEquals(stdout.includes("Options:"), true);
+    assertEquals(stderr.trim(), "");
+  });
+
+  await t.step("--version should exit with code 0", async () => {
+    const { code, stdout, stderr } = await runCLI(["--version"]);
+
+    assertEquals(code, 0);
+    assertEquals(stdout.includes("check-pr-title 1.0.0"), true);
+    assertEquals(stderr.trim(), "");
+  });
+});

--- a/scripts/check-pr-title.ts
+++ b/scripts/check-pr-title.ts
@@ -1,7 +1,7 @@
 import { parseArgs } from "jsr:@std/cli@1.0.21";
 
 const ANGULAR_FLAVORED_CONVENTIONAL_COMMITS_PREFIX_REGEX =
-  /^(build|ci|docs|feat|fix|perf|refactor|style|test)(\(.+\))?: .+/;
+  /^(build|ci|docs|feat|fix|perf|refactor|style|test)(\(.+\))?: \S.*/;
 
 type ValidationResult = { valid: true } | { valid: false; error: string };
 

--- a/scripts/check-pr-title.ts
+++ b/scripts/check-pr-title.ts
@@ -1,72 +1,72 @@
-import { echo } from "jsr:@webpod/zx@8.7.1";
 import { parseArgs } from "jsr:@std/cli@1.0.21";
 
 const ANGULAR_FLAVORED_CONVENTIONAL_COMMITS_PREFIX_REGEX =
   /^(build|ci|docs|feat|fix|perf|refactor|style|test)(\(.+\))?: .+/;
 
-const args = parseArgs(Deno.args, {
-  boolean: ["help", "version"],
-  alias: {
-    h: "help",
-    v: "version",
-  },
-});
+type ValidationResult = { valid: true } | { valid: false; error: string };
 
-if (args.help) {
-  echo("Check PR title with Angular-flavored Conventional Commits-like format");
-  echo("");
-  echo("Usage:");
-  echo("  deno run -A check-pr-title.ts <title>");
-  echo("");
-  echo("Options:");
-  echo("  -h, --help     Show help");
-  echo("  -v, --version  Show version");
+export function checkTitle(title: string): ValidationResult {
+  if (!title) {
+    return { valid: false, error: "Error: PR title is empty" };
+  }
 
-  Deno.exit(0);
+  if (!ANGULAR_FLAVORED_CONVENTIONAL_COMMITS_PREFIX_REGEX.test(title)) {
+    return {
+      valid: false,
+      error:
+        "Error: PR title does not conform to Angular-flavored Conventional Commits-like format",
+    };
+  }
+
+  return { valid: true };
 }
 
-if (args.version) {
-  echo("check-pr-title 1.0.0");
+if (import.meta.main) {
+  const args = parseArgs(Deno.args, {
+    boolean: ["help", "version"],
+    alias: {
+      h: "help",
+      v: "version",
+    },
+  });
 
-  Deno.exit(0);
-}
+  if (args.help) {
+    console.log(
+      "Check PR title with Angular-flavored Conventional Commits-like format"
+    );
+    console.log("");
+    console.log("Usage:");
+    console.log("  deno run -A check-pr-title.ts <title>");
+    console.log("");
+    console.log("Options:");
+    console.log("  -h, --help     Show help");
+    console.log("  -v, --version  Show version");
 
-if (args._.length === 0) {
-  echo("Error: PR title is not specified");
+    Deno.exit(0);
+  }
 
-  Deno.exit(1);
-}
+  if (args.version) {
+    console.log("check-pr-title 1.0.0");
 
-const title = args._.join(" ");
+    Deno.exit(0);
+  }
 
-if (!title) {
-  echo("Error: PR title is empty");
+  if (args._.length === 0) {
+    console.error("Error: PR title is not specified");
 
-  Deno.exit(1);
-}
+    Deno.exit(1);
+  }
 
-if (!ANGULAR_FLAVORED_CONVENTIONAL_COMMITS_PREFIX_REGEX.test(title)) {
-  echo(
-    "Error: PR title does not conform to Angular-flavored Conventional Commits-like format"
+  const title = args._.join(" ");
+  const result = checkTitle(title);
+
+  if (!result.valid) {
+    console.error(result.error);
+
+    Deno.exit(1);
+  }
+
+  console.log(
+    "PR title conforms to Angular-flavored Conventional Commits-like format"
   );
-
-  Deno.exit(1);
 }
-
-const match = title.match(/^([a-z]+)(\(.+\))?: (.+)$/);
-
-if (!match) {
-  echo("Error: Title format is incorrect");
-
-  Deno.exit(1);
-}
-
-const [, _type, _scope, summary] = match;
-
-if (summary.length === 0) {
-  echo("Error: Summary is empty");
-
-  Deno.exit(1);
-}
-
-echo("PR title conforms to Angular-flavored Conventional Commits-like format");

--- a/scripts/check-pr-title.ts
+++ b/scripts/check-pr-title.ts
@@ -1,0 +1,72 @@
+import { echo } from "jsr:@webpod/zx@8.7.1";
+import { parseArgs } from "jsr:@std/cli@1.0.21";
+
+const ANGULAR_FLAVORED_CONVENTIONAL_COMMITS_PREFIX_REGEX =
+  /^(build|ci|docs|feat|fix|perf|refactor|style|test)(\(.+\))?: .+/;
+
+const args = parseArgs(Deno.args, {
+  boolean: ["help", "version"],
+  alias: {
+    h: "help",
+    v: "version",
+  },
+});
+
+if (args.help) {
+  echo("Check PR title with Angular-flavored Conventional Commits-like format");
+  echo("");
+  echo("Usage:");
+  echo("  deno run -A check-pr-title.ts <title>");
+  echo("");
+  echo("Options:");
+  echo("  -h, --help     Show help");
+  echo("  -v, --version  Show version");
+
+  Deno.exit(0);
+}
+
+if (args.version) {
+  echo("check-pr-title 1.0.0");
+
+  Deno.exit(0);
+}
+
+if (args._.length === 0) {
+  echo("Error: PR title is not specified");
+
+  Deno.exit(1);
+}
+
+const title = args._.join(" ");
+
+if (!title) {
+  echo("Error: PR title is empty");
+
+  Deno.exit(1);
+}
+
+if (!ANGULAR_FLAVORED_CONVENTIONAL_COMMITS_PREFIX_REGEX.test(title)) {
+  echo(
+    "Error: PR title does not conform to Angular-flavored Conventional Commits-like format"
+  );
+
+  Deno.exit(1);
+}
+
+const match = title.match(/^([a-z]+)(\(.+\))?: (.+)$/);
+
+if (!match) {
+  echo("Error: Title format is incorrect");
+
+  Deno.exit(1);
+}
+
+const [, _type, _scope, summary] = match;
+
+if (summary.length === 0) {
+  echo("Error: Summary is empty");
+
+  Deno.exit(1);
+}
+
+echo("PR title conforms to Angular-flavored Conventional Commits-like format");

--- a/scripts/check-pr-title.ts
+++ b/scripts/check-pr-title.ts
@@ -32,7 +32,7 @@ if (import.meta.main) {
 
   if (args.help) {
     console.log(
-      "Check PR title with Angular-flavored Conventional Commits-like format"
+      "Check PR title with Angular-flavored Conventional Commits-like format",
     );
     console.log("");
     console.log("Usage:");
@@ -67,6 +67,6 @@ if (import.meta.main) {
   }
 
   console.log(
-    "PR title conforms to Angular-flavored Conventional Commits-like format"
+    "PR title conforms to Angular-flavored Conventional Commits-like format",
   );
 }


### PR DESCRIPTION
Add automated validation for PR titles to ensure they follow Angular-flavored Conventional Commits format. Includes Deno script and GitHub Actions workflow.

Closes #122

🤖 Generated with [Claude Code](https://claude.ai/code)