### PR TITLE
ci: add backquote support to PR title check

### DIFF
--- a/scripts/check-pr-title.test.ts
+++ b/scripts/check-pr-title.test.ts
@@ -35,6 +35,8 @@ Deno.test(
       "feat(router): add lazy loading",
       "fix(auth): handle token expiry",
       "docs(api): update endpoints",
+      "feat: add `console.log` for debugging",
+      "docs: update `README.md` file",
     ];
 
     for (const title of validTitles) {


### PR DESCRIPTION
## Summary
- Add support for backquotes in PR titles
- Verify existing regex pattern handles backquotes correctly
- Add test cases to ensure backquote support works properly

## Test plan
- [x] Run existing tests to ensure no regression
- [x] Verify backquotes in PR titles are now properly supported

🤖 Generated with [Claude Code](https://claude.ai/code)