### PR TITLE
ci: add temporary workaround for GPG keyserver issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+      # Temporary workaround
+      # https://github.com/Dokploy/dokploy/issues/2291
+      - run: gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 5BE8A3F6C8A5C01D106C0AD820B1A390B168D356
       - run: |
           DOTFILES_DIR=$GITHUB_WORKSPACE \
           NONINTERACTIVE=1 \
@@ -39,6 +42,9 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+      # Temporary workaround
+      # https://github.com/Dokploy/dokploy/issues/2291
+      - run: gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 5BE8A3F6C8A5C01D106C0AD820B1A390B168D356
       - run: |
           DOTFILES_DIR=$GITHUB_WORKSPACE \
           NONINTERACTIVE=1 \
@@ -54,6 +60,9 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+      # Temporary workaround
+      # https://github.com/Dokploy/dokploy/issues/2291
+      - run: gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 5BE8A3F6C8A5C01D106C0AD820B1A390B168D356
       - run: |
           DOTFILES_DIR=$GITHUB_WORKSPACE \
           NONINTERACTIVE=1 \


### PR DESCRIPTION
## Summary
- Add GPG key retrieval step to resolve keyserver connectivity issues in CI

## Details
- Added temporary workaround for GPG keyserver connectivity problem
- References https://github.com/Dokploy/dokploy/issues/2291
- Applied to all macOS jobs in the CI workflow

🤖 Generated with [Claude Code](https://claude.ai/code)