### PR TITLE
fix(vscode, zsh): disable VSCode automatic Shell Integration and load it manually in `.zshrc`

### DIFF
--- a/home/.config/zsh/.zshrc
+++ b/home/.config/zsh/.zshrc
@@ -1,6 +1,12 @@
 autoload -Uz compinit
 compinit
 
+# Enable VSCode Shell Integration manually
+# https://code.visualstudio.com/docs/terminal/shell-integration
+if [[ "$TERM_PROGRAM" == "vscode" ]]; then
+  source "$(code --locate-shell-integration-path zsh)"
+fi
+
 bindkey -v
 
 # Backward word (Shift + Arrow Left)

--- a/shared/vscode/settings.json
+++ b/shared/vscode/settings.json
@@ -16,6 +16,9 @@
   "terminal.integrated.fontSize": 13,
   "terminal.integrated.defaultProfile.osx": "zsh",
   "terminal.integrated.defaultProfile.linux": "zsh",
+  // Disable VSCode automatic Shell Integration
+  // https://code.visualstudio.com/docs/terminal/shell-integration
+  "terminal.integrated.shellIntegration.enabled": false,
   "git.autofetch": true,
   "git.blame.editorDecoration.enabled": true,
   // Referred to GitLens

--- a/shared/vscode/settings.json
+++ b/shared/vscode/settings.json
@@ -17,6 +17,7 @@
   "terminal.integrated.defaultProfile.osx": "zsh",
   "terminal.integrated.defaultProfile.linux": "zsh",
   // Disable VSCode automatic Shell Integration
+  // In GitHub Codespaces, `.zshenv` is not loaded when this is `true`, so I load it in `.zshrc`.
   // https://code.visualstudio.com/docs/terminal/shell-integration
   "terminal.integrated.shellIntegration.enabled": false,
   "git.autofetch": true,


### PR DESCRIPTION


Because in GitHub Codespaces, `.zshenv` was not loaded when automatic Shell Integration was enabled. I now load the integration script manually in `.zshrc` instead.