### PR TITLE
feat(agents): add gh-review-comment skill

### DIFF
--- a/shared/agents/skills/gh-review-comment/SKILL.md
+++ b/shared/agents/skills/gh-review-comment/SKILL.md
@@ -8,15 +8,9 @@ description: `gh` コマンドを用いて GitHub の PR レビューコメン�
 ## 返信（Reply）
 
 ```bash
-gh api repos/OWNER/REPO/pulls/comments -X POST \
-  -f body="BODY" \
-  -f commit_id="COMMIT_SHA" \
-  -f path="FILE_PATH" \
-  -F in_reply_to=COMMENT_ID
+gh api repos/OWNER/REPO/pulls/PR_NUMBER/comments/COMMENT_ID/replies -X POST \
+  -f body="BODY"
 ```
-
-> [!TIP]
-> `commit_id` は**完全な**コミットSHA（40文字）を使用します
 
 ## 解決（Resolve）
 

--- a/shared/agents/skills/gh-review-comment/SKILL.md
+++ b/shared/agents/skills/gh-review-comment/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: gh-review-comment
+description: `gh` コマンドを用いて GitHub の PR レビューコメントを操作します。レビューコメントへの返信（Reply）や解決（Resolve）するときに必ず使用してください。
+---
+
+# gh コマンドを用いた GitHub の PR レビューコメントの操作
+
+## 返信（Reply）
+
+```bash
+gh api repos/OWNER/REPO/pulls/PR_NUMBER/comments -X POST \
+  -f body="BODY" \
+  -f commit_id="COMMIT_SHA" \
+  -f path="FILE_PATH" \
+  -F in_reply_to=COMMENT_ID
+```
+
+> [!TIP]
+> `commit_id` は**完全な**コミットSHA（40文字）を使用します
+
+## 解決（Resolve）
+
+```bash
+# スレッドIDを取得
+gh api graphql -f query='
+{
+  repository(owner: "OWNER", name: "REPO") {
+    pullRequest(number: PR_NUMBER) {
+      reviewThreads(first: 10) {
+        nodes {
+          id
+          comments(first: 1) {
+            nodes {
+              databaseId
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+
+# スレッドを解決
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: {threadId: "THREAD_ID"}) {
+    thread {
+      id
+      isResolved
+    }
+  }
+}'
+```
+
+### 参考リンク
+
+- [GitHub REST API - Review comments](https://docs.github.com/rest/pulls/comments)
+- [GitHub GraphQL API - resolveReviewThread](https://docs.github.com/graphql/reference/mutations#resolvereviewthread)

--- a/shared/agents/skills/gh-review-comment/SKILL.md
+++ b/shared/agents/skills/gh-review-comment/SKILL.md
@@ -8,7 +8,7 @@ description: `gh` コマンドを用いて GitHub の PR レビューコメン�
 ## 返信（Reply）
 
 ```bash
-gh api repos/OWNER/REPO/pulls/PR_NUMBER/comments -X POST \
+gh api repos/OWNER/REPO/pulls/comments -X POST \
   -f body="BODY" \
   -f commit_id="COMMIT_SHA" \
   -f path="FILE_PATH" \


### PR DESCRIPTION
## Summary

Add a new skill for managing GitHub PR review comments using the `gh` command.

This skill provides workflows for:
- Replying to review comments
- Resolving review threads

## Changes

- Add `shared/agents/skills/gh-review-comment/SKILL.md` with detailed instructions for using `gh api` to interact with GitHub PR review comments

## Test plan

- [ ] Verify the skill documentation is clear and accurate
- [ ] Test the provided `gh` commands with actual PR review comments