### PR TITLE
feat(claude): add PermissionRequest hook for logging

### DIFF
--- a/home/.claude/hooks/log-permission.sh
+++ b/home/.claude/hooks/log-permission.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+LOG_DIR="${HOME}/.claude/logs"
+LOG_FILE="${LOG_DIR}/permission-request.jsonl"
+
+mkdir -p "${LOG_DIR}"
+
+jq -c '. + {timestamp: (now | todate)}' | tee -a "${LOG_FILE}" > /dev/null
+
+exit 0

--- a/home/.claude/hooks/log-permission.sh
+++ b/home/.claude/hooks/log-permission.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 LOG_DIR="${HOME}/.claude/logs"
 LOG_FILE="${LOG_DIR}/permission-request.jsonl"

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -9,6 +9,19 @@
       "Write(!.env*.example)"
     ]
   },
+  "hooks": {
+    "PermissionRequest": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/log-permission.sh"
+          }
+        ]
+      }
+    ]
+  },
   "statusLine": {
     "type": "command",
     "command": "bash ~/.claude/statusline.sh"

--- a/scripts/link.sh
+++ b/scripts/link.sh
@@ -14,6 +14,7 @@ is_codespaces() {
 
 dotfiles=(
   ".claude/CLAUDE.md"
+  ".claude/hooks"
   ".claude/settings.json"
   ".claude/skills"
   ".claude/statusline.sh"


### PR DESCRIPTION
## Summary

This PR adds a PermissionRequest hook that automatically logs all permission dialog events in Claude Code.

- Add `PermissionRequest` hook configuration in `settings.json`
- Create `log-permission.sh` script that logs events to `~/.claude/logs/permission-request.jsonl` in JSONL format with timestamps
- Update `link.sh` to include the `.claude/hooks` directory in dotfiles symlinks

## Test plan

- [ ] Link dotfiles and verify `~/.claude/hooks/log-permission.sh` is created
- [ ] Start Claude Code and trigger a permission dialog
- [ ] Verify that the event is logged to `~/.claude/logs/permission-request.jsonl`
- [ ] Check that the log entry contains timestamp and tool information

🤖 Generated with [Claude Code](https://claude.com/claude-code)