### PR TITLE
feat(claude): add Skill tool auto-approval to settings

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
+    "allow": [
+      "Skill"
+    ],
     "deny": [
       "Bash(sudo:*)",
       "Read(.env*)",


### PR DESCRIPTION
## Summary
- Add `Skill` tool to the `allow` list in Claude Code settings
- Enables automatic approval for Skill tool executions without manual confirmation

## Test plan
- [x] Verify settings.json syntax is valid
- [x] Test that Skill tool executes without permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)