### PR TITLE
feat(claude): add notification hooks for user input and task completion

### DIFF
--- a/home/.claude/hooks/notify-ask.sh
+++ b/home/.claude/hooks/notify-ask.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+cat > /dev/null
+
+osascript -e 'display notification "入力が必要です" with title "Claude Code"' 2>/dev/null
+
+exit 0

--- a/home/.claude/hooks/notify-stop.sh
+++ b/home/.claude/hooks/notify-stop.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+cat > /dev/null
+
+osascript -e 'display notification "タスクが完了しました" with title "Claude Code"' 2>/dev/null
+
+exit 0

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -23,6 +23,26 @@
           }
         ]
       }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/notify-ask.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/notify-stop.sh"
+          }
+        ]
+      }
     ]
   },
   "statusLine": {


### PR DESCRIPTION
## Summary
- Add `Notification` hook to send macOS notifications when Claude requests user input
- Add `Stop` hook to send macOS notifications when tasks complete

## Test plan
- [x] Run `link.sh` to link hooks
- [x] Restart Claude Code
- [x] Execute a task and verify "タスクが完了しました" notification appears
- [x] Perform an operation requiring input and verify "入力が必要です" notification appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)