### PR TITLE
feat(claude): improve notification hooks with terminal-notifier

### DIFF
--- a/home/.claude/hooks/notify-ask.sh
+++ b/home/.claude/hooks/notify-ask.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-cat > /dev/null
-
-osascript -e 'display notification "入力が必要です" with title "Claude Code"' 2>/dev/null
-
-exit 0

--- a/home/.claude/hooks/notify-stop.sh
+++ b/home/.claude/hooks/notify-stop.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-cat > /dev/null
-
-osascript -e 'display notification "タスクが完了しました" with title "Claude Code"' 2>/dev/null
-
-exit 0

--- a/home/.claude/hooks/notify.sh
+++ b/home/.claude/hooks/notify.sh
@@ -28,7 +28,7 @@ fi
 # Build subtitle: "repo on branch"
 if [ -n "$cwd" ]; then
   repo=$(basename "$cwd")
-  branch=$(cd "$cwd" && git branch --show-current 2>/dev/null)
+  branch=$(git -C "$cwd" branch --show-current 2>/dev/null)
 
   if [ -n "$branch" ]; then
     subtitle="$repo on $branch"

--- a/home/.claude/hooks/notify.sh
+++ b/home/.claude/hooks/notify.sh
@@ -20,7 +20,7 @@ case "$hook_event" in
 esac
 
 if [ -n "$input_message" ]; then
-  message="$input_message"
+  message="💬 $input_message"
 else
   message="$default_message"
 fi

--- a/home/.claude/hooks/notify.sh
+++ b/home/.claude/hooks/notify.sh
@@ -9,13 +9,13 @@ hook_event=$(echo "$input" | jq -r '.hook_event_name // empty')
 # Set default message based on hook event
 case "$hook_event" in
   "Notification")
-    default_message="入力が必要です"
+    default_message="⏸️ 入力が必要です"
     ;;
   "Stop")
-    default_message="タスクが完了しました"
+    default_message="✅ タスクが完了しました"
     ;;
   *)
-    default_message="通知"
+    default_message="📢 通知"
     ;;
 esac
 

--- a/home/.claude/hooks/notify.sh
+++ b/home/.claude/hooks/notify.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+input=$(cat)
+
+input_message=$(echo "$input" | jq -r '.message // empty')
+cwd=$(echo "$input" | jq -r '.cwd // empty')
+hook_event=$(echo "$input" | jq -r '.hook_event_name // empty')
+
+# Set default message based on hook event
+case "$hook_event" in
+  "Notification")
+    default_message="入力が必要です"
+    ;;
+  "Stop")
+    default_message="タスクが完了しました"
+    ;;
+  *)
+    default_message="通知"
+    ;;
+esac
+
+if [ -n "$input_message" ]; then
+  message="$input_message"
+else
+  message="$default_message"
+fi
+
+# Build subtitle: "repo on branch"
+if [ -n "$cwd" ]; then
+  repo=$(basename "$cwd")
+  branch=$(cd "$cwd" && git branch --show-current 2>/dev/null)
+
+  if [ -n "$branch" ]; then
+    subtitle="$repo on $branch"
+  else
+    subtitle="$repo"
+  fi
+else
+  subtitle=""
+fi
+
+# Detect terminal environment
+case "$TERM_PROGRAM" in
+  "vscode")
+    title="Claude Code on VSCode"
+    ;;
+  "ghostty")
+    title="Claude Code on Ghostty"
+    ;;
+  *)
+    title="Claude Code"
+    ;;
+esac
+
+terminal-notifier \
+  -title "$title" \
+  -subtitle "$subtitle" \
+  -message "$message" \
+  -group "claude-code" \
+  2>/dev/null
+
+exit 0

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/hooks/notify-ask.sh"
+            "command": "~/.claude/hooks/notify.sh"
           }
         ]
       }
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/hooks/notify-stop.sh"
+            "command": "~/.claude/hooks/notify.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Improves Claude Code notification hooks by consolidating scripts and enhancing notification information.

**Changes:**
- Consolidate `notify-ask.sh` and `notify-stop.sh` into a single `notify.sh` script
- Replace `osascript` with `terminal-notifier` for better notification control
- Add subtitle showing repository name and current branch (`repo on branch`)
- Add title showing terminal environment (VSCode/Ghostty)
- Implement branching logic based on `hook_event_name` field

**Benefits:**
- Reduced code duplication and improved maintainability
- Better context awareness in notifications (project and branch information)
- Clear indication of which terminal environment Claude Code is running in

## Test plan

- [x] Test notification on VSCode
- [x] Test notification on Ghostty
- [x] Verify repository and branch names appear in subtitle
- [x] Confirm notification messages display correctly for both Notification and Stop events

🤖 Generated with [Claude Code](https://claude.com/claude-code)