### PR TITLE
feat(claude): add gh view commands to allowed permissions

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -2,6 +2,9 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
+      "Bash(gh repo view:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh pr view:*)",
       "Skill"
     ],
     "deny": [


### PR DESCRIPTION
## Summary

- Add `gh repo view`, `gh issue view`, and `gh pr view` commands to the allowed permissions list in Claude Code settings

## Changes

- Updated `home/.claude/settings.json` to include read-only `gh` view commands in the permissions allow list

## Motivation

These view commands are read-only operations that allow Claude Code to fetch GitHub repository, issue, and PR information without requiring manual approval each time.