### PR TITLE
feat(claude, vscode): enable VSCode navigation from notification click

### DIFF
--- a/home/.claude/hooks/notify.sh
+++ b/home/.claude/hooks/notify.sh
@@ -43,6 +43,7 @@ fi
 case "$TERM_PROGRAM" in
   "vscode")
     title="Claude Code on VSCode"
+    open_url="vscode://file/$cwd"
     ;;
   "ghostty")
     title="Claude Code on Ghostty"
@@ -52,11 +53,14 @@ case "$TERM_PROGRAM" in
     ;;
 esac
 
-terminal-notifier \
-  -title "$title" \
-  -subtitle "$subtitle" \
-  -message "$message" \
-  -group "claude-code" \
-  2>/dev/null
+# Build terminal-notifier command
+notifier_cmd=(terminal-notifier -title "$title" -subtitle "$subtitle" -message "$message" -group "claude-code")
+
+# Add -open option if open_url is set
+if [ -n "$open_url" ]; then
+  notifier_cmd+=(-open "$open_url")
+fi
+
+"${notifier_cmd[@]}" 2>/dev/null
 
 exit 0

--- a/home/.claude/hooks/notify.sh
+++ b/home/.claude/hooks/notify.sh
@@ -43,7 +43,9 @@ fi
 case "$TERM_PROGRAM" in
   "vscode")
     title="Claude Code on VSCode"
-    open_url="vscode://file/$cwd"
+    if [ -n "$cwd" ]; then
+      open_url="vscode://file/$cwd"
+    fi
     ;;
   "ghostty")
     title="Claude Code on Ghostty"

--- a/shared/vscode/settings.json
+++ b/shared/vscode/settings.json
@@ -24,6 +24,7 @@
   // In GitHub Codespaces, `.zshenv` is not loaded when this is `true`, so I load it in `.zshrc`.
   // https://code.visualstudio.com/docs/terminal/shell-integration
   "terminal.integrated.shellIntegration.enabled": false,
+  "security.promptForLocalFileProtocolHandling": false,
   "git.autofetch": true,
   "git.blame.editorDecoration.enabled": true,
   // Referred to GitLens

--- a/shared/vscode/settings.json
+++ b/shared/vscode/settings.json
@@ -24,6 +24,7 @@
   // In GitHub Codespaces, `.zshenv` is not loaded when this is `true`, so I load it in `.zshrc`.
   // https://code.visualstudio.com/docs/terminal/shell-integration
   "terminal.integrated.shellIntegration.enabled": false,
+  // Prevent confirmation prompts when handling vscode:// URLs (e.g. links in notifications).
   "security.promptForLocalFileProtocolHandling": false,
   "git.autofetch": true,
   "git.blame.editorDecoration.enabled": true,


### PR DESCRIPTION
## Summary
- Enable opening the working directory in VSCode by clicking the notification when running Claude Code inside VSCode terminal
- Implemented using `vscode://file/$cwd` URL scheme

## Changes
- `home/.claude/hooks/notify.sh`: Add `vscode://` URL support for VSCode environment notifications
- `shared/vscode/settings.json`: Disable local file protocol handling confirmation prompt

## Test plan
- [x] Run Claude Code in VSCode terminal
- [x] Verify notification is displayed
- [x] Click notification and verify working directory opens in VSCode
- [x] Verify other terminals (e.g., Ghostty) work as before