### PR TITLE
feat(copilot): add review guidelines for PR comments

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,12 +2,15 @@
 
 ## Comment Prefixes
 
-When writing Pull Request review comments, always use one of the following prefixes.
+When writing Pull Request review comments, always use one of the following
+prefixes.
 
 ### Prefix Types
 
-- **MUST**: Critical issues that must be fixed (security, bugs, specification violations, etc.)
-- **SHOULD**: Recommended changes (performance, maintainability, best practices, etc.)
+- **MUST**: Critical issues that must be fixed (security, bugs, specification
+  violations, etc.)
+- **SHOULD**: Recommended changes (performance, maintainability, best practices,
+  etc.)
 - **IMO**: Personal opinions or suggestions (In My Opinion)
 - **NITS**: Minor issues (typos, formatting, small naming improvements, etc.)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,24 @@
+# Review Guidelines
+
+## Comment Prefixes
+
+When writing Pull Request review comments, always use one of the following prefixes.
+
+### Prefix Types
+
+- **MUST**: Critical issues that must be fixed (security, bugs, specification violations, etc.)
+- **SHOULD**: Recommended changes (performance, maintainability, best practices, etc.)
+- **IMO**: Personal opinions or suggestions (In My Opinion)
+- **NITS**: Minor issues (typos, formatting, small naming improvements, etc.)
+
+### Examples
+
+```
+MUST: This implementation may introduce an XSS vulnerability. Please add input escaping.
+
+SHOULD: This process can be parallelized using Promise.all.
+
+IMO: I think `userData` would be a clearer variable name here.
+
+NITS: Indentation is inconsistent.
+```


### PR DESCRIPTION
## Summary

- Add `.github/copilot-instructions.md` to provide review comment guidelines for GitHub Copilot
- Define four prefix types for PR review comments:
  - **MUST**: Critical issues that must be fixed
  - **SHOULD**: Recommended changes
  - **IMO**: Personal opinions or suggestions
  - **NITS**: Minor issues

## Test plan

- [x] Verify the file is created at `.github/copilot-instructions.md`
- [ ] Confirm GitHub Copilot reads and applies these guidelines in future PR reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)