### PR TITLE
feat(claude): add gh run view to allowed permissions

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -5,6 +5,7 @@
       "Bash(gh repo view:*)",
       "Bash(gh issue view:*)",
       "Bash(gh pr view:*)",
+      "Bash(gh run view:*)",
       "Skill"
     ],
     "deny": [


### PR DESCRIPTION
## Summary
- Add `gh run view` to the allowed permissions list in Claude Code settings
- This allows Claude to view GitHub Actions workflow runs without requiring user approval, similar to other `gh view` commands

## Test plan
- Verify the setting is correctly added to `home/.claude/settings.json`
- Confirm Claude can execute `gh run view` commands without permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)