### PR TITLE
feat(claude): add git log to allowed permissions

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
+      "Bash(git log:*)",
       "Bash(gh repo view:*)",
       "Bash(gh issue view:*)",
       "Bash(gh pr view:*)",


### PR DESCRIPTION
## Summary
- Add `git log` command to allowed permissions in Claude settings

## Test plan
- [x] Verify that `git log` commands can be executed without permission prompts