### PR TITLE
feat(claude): add package manager run commands to allowed permissions

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -7,6 +7,10 @@
       "Bash(gh issue view:*)",
       "Bash(gh pr view:*)",
       "Bash(gh run view:*)",
+      "Bash(npm run:*)",
+      "Bash(yarn run:*)",
+      "Bash(pnpm run:*)",
+      "Bash(bun run:*)",
       "Skill"
     ],
     "deny": [


### PR DESCRIPTION
## Summary
- Added npm, yarn, pnpm, and bun `run` commands to Claude Code's allowed permissions list

## Test plan
- [x] Verify settings file syntax is correct
- [ ] Confirm each package manager's run command can be executed without approval in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)