### PR TITLE
feat(mise): add jq with platform-specific asset patterns

### DIFF
--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -18,6 +18,21 @@ deno = "latest"
 "npm:pnpm" = "latest"
 "npm:yarn" = "latest"
 
+[tools."github:jqlang/jq"]
+version = "latest"
+
+[tools."github:jqlang/jq".platforms]
+macos-x64 = { asset_pattern = "jq-macos-amd64" }
+macos-arm64 = { asset_pattern = "jq-macos-arm64" }
+linux-x64 = { asset_pattern = "jq-linux-amd64" }
+linux-x64-musl = { asset_pattern = "jq-linux-amd64" }
+linux-arm64 = { asset_pattern = "jq-linux-arm64" }
+linux-arm64-musl = { asset_pattern = "jq-linux-arm64" }
+linux-armv6 = { asset_pattern = "jq-linux-armel" }
+linux-armv6-musl = { asset_pattern = "jq-linux-armel" }
+linux-armv7 = { asset_pattern = "jq-linux-armhf" }
+linux-armv7-musl = { asset_pattern = "jq-linux-armhf" }
+
 [settings]
 experimental = true
 idiomatic_version_file_enable_tools = ['node']


### PR DESCRIPTION
## Summary
- Add jq to mise configuration
- Configure platform-specific asset patterns for macOS and Linux