### PR TITLE
feat(claude): add directory, branch, and PR info to statusline

### DIFF
--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -31,7 +31,7 @@ if git rev-parse --git-dir >/dev/null 2>&1; then
   git_branch=$(git branch --show-current 2>/dev/null)
 fi
 
-# Get PR numbers with hyperlinks (requires gh CLI)
+# Get PR numbers with hyperlinks (if gh CLI is available)
 pr_numbers=""
 if command -v gh >/dev/null 2>&1; then
   repo_url=$(gh repo view --json url -q .url 2>/dev/null)

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -13,7 +13,7 @@ fi
 
 # ANSI color codes
 GREEN=$'\033[32m'
-CYAN=$'\033[36m'
+BLUE=$'\033[34m'
 YELLOW=$'\033[33m'
 RESET=$'\033[0m'
 
@@ -158,7 +158,7 @@ if [[ -n "$git_branch" ]]; then
   output+=" on ${GREEN}${git_branch}${RESET}"
 fi
 if [[ -n "$pr_numbers" ]]; then
-  output+=" ${CYAN}(${pr_numbers})${RESET}"
+  output+=" ${BLUE}(${pr_numbers})${RESET}"
 fi
 
 # Model

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Claude Code statusline
-# Format: currentDir on branchName #PR | Model: <model> | Context: <pct>% | 5h: <pct>% (<time>) | 7d: <pct>% (<time>)
+# Format: currentDir on branchName (#PR1, #PR2) | Model: <model> | Context: <pct>% | 5h: <pct>% (<time>) | 7d: <pct>% (<time>)
 
 # Read JSON input from stdin (if available)
 input=$(cat 2>/dev/null || echo '{}')

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -37,7 +37,7 @@ if command -v gh >/dev/null 2>&1; then
   repo_url=$(gh repo view --json url -q .url 2>/dev/null)
   if [[ -n "$repo_url" ]]; then
     # Get all PR numbers and format as clickable links
-    pr_list=$(gh pr list --head "$(git branch --show-current 2>/dev/null)" --json number -q '.[].number' 2>/dev/null)
+    pr_list=$(gh pr list --head "$git_branch" --json number -q '.[].number' 2>/dev/null)
     pr_links=""
     while IFS= read -r num; do
       [[ -z "$num" ]] && continue


### PR DESCRIPTION
## Summary
- Display current directory, git branch, and PR numbers in StatusLine
- Color scheme matches starship.toml (yellow for directory, green for branch, cyan for PR)
- PR numbers are clickable hyperlinks using OSC 8
- Support multiple PRs per branch

## Test plan
- [x] Restart Claude Code and verify StatusLine displays correctly
- [x] Test in a git repository with active PRs
- [x] Verify colors match starship prompt
- [x] Click PR number to confirm hyperlink works