### PR TITLE
feat(gh): add reply-review-comment alias

### DIFF
--- a/home/.config/gh/config.yml
+++ b/home/.config/gh/config.yml
@@ -1,2 +1,5 @@
 version: 1
 git_protocol: ssh
+aliases:
+  # $1: PR number, $2: comment ID, $3: reply body
+  reply-review-comment: 'api -X POST "repos/{owner}/{repo}/pulls/$1/comments/$2/replies" -f body="$3"'


### PR DESCRIPTION
## Summary
- Add `reply-review-comment` alias to `gh` config
- Enables replying to PR review comments via GitHub API

## Usage
```bash
gh reply-review-comment <PR number> <comment ID> <reply body>
```

Parameters:
- `{owner}` and `{repo}`: Auto-populated from current repository or `GH_REPO` env var
- `$1`: PR number
- `$2`: Comment ID
- `$3`: Reply body

🤖 Generated with [Claude Code](https://claude.com/claude-code)