### PR TITLE
feat(gh): add resolve-review-thread alias

### DIFF
--- a/home/.config/gh/config.yml
+++ b/home/.config/gh/config.yml
@@ -3,3 +3,5 @@ git_protocol: ssh
 aliases:
   # $1: PR number, $2: comment ID, $3: reply body
   reply-review-comment: 'api -X POST "repos/{owner}/{repo}/pulls/$1/comments/$2/replies" -f body="$3"'
+  # $1: thread ID (PRRT_...)
+  resolve-review-thread: 'api graphql -f query=''mutation { resolveReviewThread(input: {threadId: "$1"}) { thread { id isResolved } } }'''

--- a/home/.config/gh/config.yml
+++ b/home/.config/gh/config.yml
@@ -4,4 +4,4 @@ aliases:
   # $1: PR number, $2: comment ID, $3: reply body
   reply-review-comment: 'api -X POST "repos/{owner}/{repo}/pulls/$1/comments/$2/replies" -f body="$3"'
   # $1: thread ID (PRRT_...)
-  resolve-review-thread: 'api graphql -f query=''mutation { resolveReviewThread(input: {threadId: "$1"}) { thread { id isResolved } } }'''
+  resolve-review-thread: 'api graphql -f query=''mutation($threadId: ID!) { resolveReviewThread(input: {threadId: $threadId}) { thread { id isResolved } } }'' -f threadId="$1"'


### PR DESCRIPTION
## Summary
- Add `resolve-review-thread` alias to resolve PR review threads via GraphQL API
- Usage: `gh resolve-review-thread PRRT_...`

## Test plan
- [ ] Run `gh resolve-review-thread <thread-id>` on an open review thread