### PR TITLE
feat(ghostty): add split/tab keybinds and unfocused opacity

### DIFF
--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -7,11 +7,16 @@ font-thicken = true
 theme = one-dark-pro
 cursor-style = block
 background-opacity = 0.75
+unfocused-split-opacity = 0.75
+split-divider-color = #3e4452
 fullscreen = true
 keybind = global:alt+space=toggle_visibility
 keybind = cmd+r=clear_screen
 # https://github.com/anthropics/claude-code/issues/1282
 keybind = shift+enter=text:\n
+keybind = cmd+shift+e=equalize_splits
+keybind = cmd+shift+left=move_tab:-1
+keybind = cmd+shift+right=move_tab:1
 window-padding-x = 8
 window-padding-y = 8
 shell-integration-features = no-cursor


### PR DESCRIPTION
## Summary

- Add unfocused split opacity and split divider color settings
- Add iTerm2-like keybinds:
  - `Cmd+Shift+E`: Equalize splits
  - `Cmd+Shift+Left/Right`: Move tab left/right