### PR TITLE
feat(gh): add get-review-comments alias

### DIFF
--- a/home/.config/gh/config.yml
+++ b/home/.config/gh/config.yml
@@ -5,3 +5,5 @@ aliases:
   reply-review-comment: 'api -X POST "repos/{owner}/{repo}/pulls/$1/comments/$2/replies" -f body="$3"'
   # $1: thread ID (PRRT_...)
   resolve-review-thread: 'api graphql -f query=''mutation($threadId: ID!) { resolveReviewThread(input: {threadId: $threadId}) { thread { id isResolved } } }'' -f threadId="$1"'
+  # $1: owner, $2: repo, $3: PR number
+  get-review-comments: 'api graphql -f query=''query($owner: String!, $repo: String!, $pr: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $pr) { reviewThreads(first: 100) { nodes { id isResolved comments(first: 10) { nodes { databaseId body author { login } createdAt } } } } } } }'' -f owner="$1" -f repo="$2" -F pr="$3"'

--- a/home/.config/gh/config.yml
+++ b/home/.config/gh/config.yml
@@ -1,9 +1,9 @@
 version: 1
 git_protocol: ssh
 aliases:
+  # $1: owner, $2: repo, $3: PR number
+  get-review-comments: 'api graphql -f query=''query($owner: String!, $repo: String!, $pr: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $pr) { reviewThreads(first: 100) { nodes { id isResolved comments(first: 10) { nodes { databaseId body author { login } createdAt } } } } } } }'' -f owner="$1" -f repo="$2" -F pr="$3"'
   # $1: PR number, $2: comment ID, $3: reply body
   reply-review-comment: 'api -X POST "repos/{owner}/{repo}/pulls/$1/comments/$2/replies" -f body="$3"'
   # $1: thread ID (PRRT_...)
   resolve-review-thread: 'api graphql -f query=''mutation($threadId: ID!) { resolveReviewThread(input: {threadId: $threadId}) { thread { id isResolved } } }'' -f threadId="$1"'
-  # $1: owner, $2: repo, $3: PR number
-  get-review-comments: 'api graphql -f query=''query($owner: String!, $repo: String!, $pr: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $pr) { reviewThreads(first: 100) { nodes { id isResolved comments(first: 10) { nodes { databaseId body author { login } createdAt } } } } } } }'' -f owner="$1" -f repo="$2" -F pr="$3"'

--- a/home/.config/gh/config.yml
+++ b/home/.config/gh/config.yml
@@ -2,7 +2,7 @@ version: 1
 git_protocol: ssh
 aliases:
   # $1: owner, $2: repo, $3: PR number
-  get-review-comments: 'api graphql -f query=''query($owner: String!, $repo: String!, $pr: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $pr) { reviewThreads(first: 100) { nodes { id isResolved comments(first: 10) { nodes { databaseId body author { login } createdAt } } } } } } }'' -f owner="$1" -f repo="$2" -F pr="$3"'
+  get-review-comments: 'api graphql -f query=''query($owner: String!, $repo: String!, $pr: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $pr) { reviewThreads(first: 100) { nodes { id isResolved comments(first: 100) { nodes { databaseId body author { login } createdAt } } } } } } }'' -f owner="$1" -f repo="$2" -F pr="$3"'
   # $1: PR number, $2: comment ID, $3: reply body
   reply-review-comment: 'api -X POST "repos/{owner}/{repo}/pulls/$1/comments/$2/replies" -f body="$3"'
   # $1: thread ID (PRRT_...)


### PR DESCRIPTION
## Summary

- Add `get-review-comments` alias to fetch PR review threads via GraphQL
- Returns thread ID (for resolving) and comment databaseId (for replying)

## Usage

```bash
gh get-review-comments <owner> <repo> <pr-number>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)