### PR TITLE
feat(claude): add WebFetch permission for GitHub domains

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -9,6 +9,8 @@
       "Bash(gh pr diff:*)",
       "Bash(gh pr view:*)",
       "Bash(gh run view:*)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:raw.githubusercontent.com)",
       "Skill"
     ],
     "deny": [


### PR DESCRIPTION
## Summary
- Add WebFetch permission for `github.com`
- Add WebFetch permission for `raw.githubusercontent.com`

## Test plan
- [x] Verify WebFetch works for GitHub URLs without permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)