### PR TITLE
feat(gh): add request-review-to-copilot alias

### DIFF
--- a/home/.config/gh/config.yml
+++ b/home/.config/gh/config.yml
@@ -1,6 +1,8 @@
 version: 1
 git_protocol: ssh
 aliases:
+  # $1: PR number
+  request-review-to-copilot: api --method POST /repos/{owner}/{repo}/pulls/$1/requested_reviewers -f "reviewers[]=copilot-pull-request-reviewer[bot]"
   # $1: owner, $2: repo, $3: PR number
   get-review-comments: 'api graphql -f query=''query($owner: String!, $repo: String!, $pr: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $pr) { reviewThreads(first: 100) { nodes { id isResolved comments(first: 100) { nodes { databaseId body author { login } createdAt } } } } } } }'' -f owner="$1" -f repo="$2" -F pr="$3"'
   # $1: PR number, $2: comment ID, $3: reply body


### PR DESCRIPTION
## Summary

- Add `request-review-to-copilot` alias to request code review from GitHub Copilot via gh CLI

## Usage

```bash
gh request-review-to-copilot <PR number>
```

## Reference

- https://github.com/cli/cli/issues/10598#issuecomment-2893526162