### PR TITLE
feat(claude): add gh pr list to allowed permissions

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -7,6 +7,7 @@
       "Bash(gh issue view:*)",
       "Bash(gh pr checks:*)",
       "Bash(gh pr diff:*)",
+      "Bash(gh pr list:*)",
       "Bash(gh pr view:*)",
       "Bash(gh run view:*)",
       "WebFetch(domain:github.com)",


### PR DESCRIPTION
## Summary

- Add `gh pr list` command to allowed permissions in Claude Code settings