### PR TITLE
feat(ghostty): use maximize instead of fullscreen

### DIFF
--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -9,7 +9,7 @@ cursor-style = block
 background-opacity = 0.75
 unfocused-split-opacity = 0.75
 split-divider-color = #3e4452
-fullscreen = true
+maximize = true
 keybind = global:alt+space=toggle_visibility
 keybind = cmd+r=clear_screen
 # https://github.com/anthropics/claude-code/issues/1282


### PR DESCRIPTION
## Summary

- Change ghostty startup setting from `fullscreen` to `maximize`

🤖 Generated with [Claude Code](https://claude.com/claude-code)