### PR TITLE
feat(ghostty): add macos-titlebar-style tabs

### DIFF
--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -21,5 +21,6 @@ window-padding-x = 8
 window-padding-y = 8
 shell-integration-features = no-cursor
 macos-non-native-fullscreen = true
+macos-titlebar-style = tabs
 # https://github.com/ghostty-org/ghostty/issues/6086#issuecomment-2829417634
 macos-window-shadow = false


### PR DESCRIPTION
## Summary
- Add `macos-titlebar-style = tabs` to Ghostty config

🤖 Generated with [Claude Code](https://claude.com/claude-code)