### PR TITLE
feat(claude): simplify gh command permissions with wildcards

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -3,13 +3,11 @@
   "permissions": {
     "allow": [
       "Bash(git log:*)",
-      "Bash(gh repo view:*)",
-      "Bash(gh issue view:*)",
+      "Bash(gh * list:*)",
+      "Bash(gh * status:*)",
+      "Bash(gh * view:*)",
       "Bash(gh pr checks:*)",
       "Bash(gh pr diff:*)",
-      "Bash(gh pr list:*)",
-      "Bash(gh pr view:*)",
-      "Bash(gh run view:*)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:raw.githubusercontent.com)",
       "Skill"


### PR DESCRIPTION
## Summary
- Replace specific `gh` command permissions with wildcard patterns
- Consolidate `gh repo view`, `gh issue view`, `gh pr list/view`, `gh run view` into `gh * list/status/view`

## Test plan
- Verify that `gh` commands work correctly with the new wildcard permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)