### PR TITLE
fix: prevent jq parse error in gh-notify-copilot-review

### DIFF
--- a/bin/gh-notify-copilot-review
+++ b/bin/gh-notify-copilot-review
@@ -54,11 +54,8 @@ while true; do
     echo "Timeout: No Copilot review after 1 hour"
     exit 1
   fi
-  # Get review information
-  reviews=$(gh pr view --json reviews 2>/dev/null | jq -r '.reviews')
-
-  # Check for Copilot reviews (only COMMENTED state, ignore PENDING)
-  copilot_commented=$(echo "$reviews" | jq -r --arg bot "$copilot_bot" '[.[] | select(.author.login == $bot and .state == "COMMENTED")] | length')
+  # Get review information and check for Copilot reviews (only COMMENTED state, ignore PENDING)
+  copilot_commented=$(gh pr view --json reviews 2>/dev/null | jq -r --arg bot "$copilot_bot" '[.reviews[] | select(.author.login == $bot and .state == "COMMENTED")] | length')
 
   if [[ $copilot_commented -gt $last_review_count ]]; then
     # Copilot review completed


### PR DESCRIPTION
## Summary

- Fix jq parse error in `gh-notify-copilot-review` when review comments contain control characters
- Remove intermediate variable and pipe JSON directly from gh to jq
- Avoids double parsing that caused `jq: parse error: Invalid string: control characters from U+0000 through U+001F must be escaped`

## Test plan

- [ ] Verify `gh-notify-copilot-review` works correctly when Copilot leaves review comments with special characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)