### PR TITLE
fix: correct Copilot bot name in gh-notify-copilot-review

### DIFF
--- a/bin/gh-notify-copilot-review
+++ b/bin/gh-notify-copilot-review
@@ -39,7 +39,7 @@ group_id="gh-copilot-${repo_owner}-${repo_name}-${pr_number}"
 last_review_count=0
 
 # Copilot bot name to watch for
-copilot_bot="copilot-pull-request-reviewer[bot]"
+copilot_bot="copilot-pull-request-reviewer"
 
 # Timeout after 1 hour (3600 seconds)
 timeout=3600


### PR DESCRIPTION
## Summary

- Fix Copilot bot name to match actual API response
- `gh pr view --json reviews` returns `"copilot-pull-request-reviewer"` without `[bot]` suffix
- This fix ensures the script properly detects Copilot reviews

## Test plan

- [ ] Verify `gh-notify-copilot-review` correctly detects Copilot reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)