### PR TITLE
feat(claude): add tail command permission

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -10,6 +10,7 @@
       "Bash(gh pr list:*)",
       "Bash(gh pr view:*)",
       "Bash(gh run view:*)",
+      "Bash(tail:*)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:raw.githubusercontent.com)",
       "Skill"


### PR DESCRIPTION
## Summary
- Add `tail` command permission to Claude settings

This allows Claude to use the `tail` command for reading file outputs, which is useful for monitoring background task outputs.

## Test plan
- [ ] Verify settings.json changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)