### PR TITLE
feat(claude): add get-review-comments permission

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -10,6 +10,7 @@
       "Bash(gh pr list:*)",
       "Bash(gh pr view:*)",
       "Bash(gh run view:*)",
+      "Bash(gh get-review-comments:*)",
       "Bash(tail:*)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:raw.githubusercontent.com)",


### PR DESCRIPTION
## Summary
- Add `gh get-review-comments` alias permission to Claude settings

This allows Claude to retrieve PR review comments using the custom gh alias, which is useful for handling Copilot review feedback.

## Test plan
- [ ] Verify settings.json changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)