### PR TITLE
feat(mise, zsh): add zoxide integration

### DIFF
--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -2,6 +2,7 @@
 node = "lts"
 bun = "latest"
 deno = "latest"
+"github:ajeetdsouza/zoxide" = "latest"
 "github:cli/cli" = "latest"
 "github:eza-community/eza" = { version = "latest", os = ["linux"] }
 "github:jkfran/killport" = "latest"

--- a/home/.config/zsh/.zshrc
+++ b/home/.config/zsh/.zshrc
@@ -30,6 +30,10 @@ if type fzf &>/dev/null; then
   source <(fzf --zsh)
 fi
 
+if type zoxide &>/dev/null; then
+  eval "$(zoxide init zsh)"
+fi
+
 export FZF_DEFAULT_OPTS="--layout=reverse"
 
 HISTSIZE=100000


### PR DESCRIPTION
## Summary
- Add zoxide installation via mise
- Initialize zoxide in zsh for smarter directory navigation

## Test plan
- [ ] zoxide is installed by `mise install`
- [ ] `z` command works after restarting zsh
- [ ] Can quickly navigate to frequently used directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)