### PR TITLE
fix(claude): adjust context percentage for auto-compact threshold

### DIFF
--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -210,9 +210,10 @@ if [[ -n "$model" && "$model" != "null" ]]; then
   output+=" ${GRAY}|${RESET} Model: ${ORANGE}${model}${RESET}"
 fi
 
-# Context usage
+# Context usage (use 80% of context_size as 100% since auto-compact triggers at 80%)
 if [[ -n "$context_size" && -n "$current_tokens" && "$context_size" != "null" && "$current_tokens" != "null" && "$context_size" -gt 0 ]]; then
-  percent=$((current_tokens * 100 / context_size))
+  effective_size=$((context_size * 80 / 100))
+  percent=$((current_tokens * 100 / effective_size))
   output+=" ${GRAY}|${RESET} Context: ${percent}%"
 fi
 

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -213,8 +213,10 @@ fi
 # Context usage (use 80% of context_size as 100% since auto-compact triggers at 80%)
 if [[ -n "$context_size" && -n "$current_tokens" && "$context_size" != "null" && "$current_tokens" != "null" && "$context_size" -gt 0 ]]; then
   effective_size=$((context_size * 80 / 100))
-  percent=$((current_tokens * 100 / effective_size))
-  output+=" ${GRAY}|${RESET} Context: ${percent}%"
+  if [[ "$effective_size" -gt 0 ]]; then
+    percent=$((current_tokens * 100 / effective_size))
+    output+=" ${GRAY}|${RESET} Context: ${percent}%"
+  fi
 fi
 
 # Usage section


### PR DESCRIPTION
## Summary

- Adjust context usage calculation based on auto-compact threshold (80%)
- Use 160K as 100% for 200K context window
- Context: 100% now indicates auto-compact is about to trigger

## References

- [ccstatusline](https://github.com/sirmalloc/ccstatusline) - "accounting for auto-compact at 80%"
- [Issue #9964](https://github.com/anthropics/claude-code/issues/9964) - Auto-compact threshold: 160K (80% of 200K)