### PR TITLE
feat(ghostty): add tmux auto-start on launch

### DIFF
--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -8,6 +8,7 @@ theme = one-dark-pro
 cursor-style = block
 background-opacity = 0.75
 background-opacity-cells = true
+command = zsh -l -i -c "tmux new-session -A -s main"
 maximize = true
 keybind = global:alt+space=toggle_visibility
 keybind = cmd+r=text:\x0c


### PR DESCRIPTION
## Summary

- Auto-connect to tmux `main` session when Ghostty launches
- Use `zsh -l -i -c` to load shell config for proper PATH setup with mise

## Test plan

- [ ] Restart Ghostty and verify tmux starts automatically
- [ ] Exit tmux and verify it falls back to zsh shell

🤖 Generated with [Claude Code](https://claude.ai/code)