### PR TITLE
feat(claude): add gh release view permission

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -3,6 +3,7 @@
   "permissions": {
     "allow": [
       "Bash(git log:*)",
+      "Bash(gh release view:*)",
       "Bash(gh repo view:*)",
       "Bash(gh issue view:*)",
       "Bash(gh pr checks:*)",


### PR DESCRIPTION
## Summary

- Add `gh release view` command to allowed permissions

This is a read-only command, so it should be auto-approved.