### PR TITLE
feat(tmux): add split pane keybindings to inherit current directory

### DIFF
--- a/home/.config/tmux/tmux.conf
+++ b/home/.config/tmux/tmux.conf
@@ -12,6 +12,9 @@ set -g pane-base-index 1
 # Keybindings
 # New window (limit 9)
 bind c if-shell "[ #{session_windows} -lt 9 ]" "new-window" ""
+# Split pane (inherit current directory)
+bind '"' split-window -v -c "#{pane_current_path}"
+bind % split-window -h -c "#{pane_current_path}"
 # Close pane or window
 bind w if-shell "[ #{window_panes} -gt 1 ]" "kill-pane" "kill-window"
 # Move window (left/right)


### PR DESCRIPTION
Add settings to inherit the current directory when splitting panes.

- Configure `prefix + "` (vertical split) and `prefix + %` (horizontal split) to inherit the current directory