### PR TITLE
feat(tmux): add Claude Code status indicator to window title

### DIFF
--- a/home/.config/tmux/scripts/claude-code-status.sh
+++ b/home/.config/tmux/scripts/claude-code-status.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # Claude Code status indicator for tmux window
 # Usage: claude-code-status.sh <window_id>
 

--- a/home/.config/tmux/scripts/claude-code-status.sh
+++ b/home/.config/tmux/scripts/claude-code-status.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Claude Code status indicator for tmux window
+# Usage: claude-status.sh <window_id>
+
+window_id="${1:-}"
+
+if [[ -z "$window_id" ]]; then
+  exit 0
+fi
+
+# Get pane titles for the specified window
+pane_titles=$(tmux list-panes -t "$window_id" -F '#{pane_title}' 2>/dev/null)
+
+if [[ -z "$pane_titles" ]]; then
+  exit 0
+fi
+
+# Check for Claude Code status
+# ⠐ (U+2810) or ⠂ (U+2802) = running (spinner animation)
+# ✳ (U+2733) = idle (waiting for input)
+if echo "$pane_titles" | grep -q '[⠐⠂]'; then
+  # Alternate between ⠐ and ⠂ based on current second
+  if (( $(date +%s) % 2 == 0 )); then
+    printf ' ⠐'
+  else
+    printf ' ⠂'
+  fi
+elif echo "$pane_titles" | grep -q '✳'; then
+  printf ' ✳'  # Idle
+fi

--- a/home/.config/tmux/scripts/claude-code-status.sh
+++ b/home/.config/tmux/scripts/claude-code-status.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Claude Code status indicator for tmux window
-# Usage: claude-status.sh <window_id>
+# Usage: claude-code-status.sh <window_id>
 
 window_id="${1:-}"
 

--- a/home/.config/tmux/scripts/claude-code-status.sh
+++ b/home/.config/tmux/scripts/claude-code-status.sh
@@ -19,13 +19,13 @@ fi
 # Check for Claude Code status
 # ⠐ (U+2810) or ⠂ (U+2802) = running (spinner animation)
 # ✳ (U+2733) = idle (waiting for input)
-if echo "$pane_titles" | grep -q '[⠐⠂]'; then
+if [[ "$pane_titles" =~ [⠐⠂] ]]; then
   # Alternate between ⠐ and ⠂ based on current second
   if (( $(date +%s) % 2 == 0 )); then
     printf ' ⠐'
   else
     printf ' ⠂'
   fi
-elif echo "$pane_titles" | grep -q '✳'; then
+elif [[ "$pane_titles" == *✳* ]]; then
   printf ' ✳'  # Idle
 fi

--- a/home/.config/tmux/tmux.conf
+++ b/home/.config/tmux/tmux.conf
@@ -22,10 +22,11 @@ bind H swap-window -t -1\; select-window -t -1
 bind L swap-window -t +1\; select-window -t +1
 
 # Status bar
+set -g status-interval 1
 set -g status-position top
 set -g status-style 'bg=default,fg=white'
-set -g window-status-format '  #I:#W  '
-set -g window-status-current-format '  #I:#W  '
+set -g window-status-format '  #I:#W#(~/.config/tmux/scripts/claude-code-status.sh #I)  '
+set -g window-status-current-format '  #I:#W#(~/.config/tmux/scripts/claude-code-status.sh #I)  '
 set -g window-status-current-style 'bg=#3e4452,fg=brightwhite'
 set -g status-right '#{pane_title}'
 


### PR DESCRIPTION
## Summary

- Add a script to detect Claude Code status from tmux pane titles
- Display status indicator (✳ idle / ⠐⠂ running) in window title
- Set status-interval to 1 second for responsive updates

## Test plan

- [x] Verify ✳ appears when Claude Code is idle
- [x] Verify ⠐/⠂ alternates when Claude Code is running
- [x] Verify no indicator appears when Claude Code is not running

🤖 Generated with [Claude Code](https://claude.com/claude-code)