### PR TITLE
fix(claude, ghostty): enable Option key as Alt for Claude Code model switching

### DIFF
--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -45,5 +45,6 @@ window-padding-y = 8
 shell-integration-features = no-cursor
 macos-non-native-fullscreen = true
 macos-titlebar-style = hidden
+macos-option-as-alt = true
 # https://github.com/ghostty-org/ghostty/issues/6086#issuecomment-2829417634
 macos-window-shadow = false


### PR DESCRIPTION
## Summary

- Add `macos-option-as-alt = true` to Ghostty config to enable Option + p keybinding for Claude Code model switching in tmux

## Test plan

- [x] Restart Ghostty or reload config
- [x] Open Claude Code inside tmux
- [x] Press Option + p and verify model switching dialog appears

Closes #340

🤖 Generated with [Claude Code](https://claude.ai/code)