### PR TITLE
feat(tmux): disable pane navigation wrap-around

### DIFF
--- a/home/.config/tmux/tmux.conf
+++ b/home/.config/tmux/tmux.conf
@@ -5,6 +5,12 @@ set -as terminal-features ",xterm-256color:RGB"
 # Mouse support
 set -g mouse on
 
+# Pane navigation without wrap-around
+bind -r Left if-shell "[ $(tmux display -p '#{pane_at_left}') -eq 0 ]" "select-pane -L"
+bind -r Right if-shell "[ $(tmux display -p '#{pane_at_right}') -eq 0 ]" "select-pane -R"
+bind -r Up if-shell "[ $(tmux display -p '#{pane_at_top}') -eq 0 ]" "select-pane -U"
+bind -r Down if-shell "[ $(tmux display -p '#{pane_at_bottom}') -eq 0 ]" "select-pane -D"
+
 # Start window/pane numbering at 1
 set -g base-index 1
 set -g pane-base-index 1


### PR DESCRIPTION
## Summary

- Prevent pane navigation from wrapping to the opposite side when at edge
- When using `prefix + arrow keys`, no action is taken if already at the edge

## Test plan

- [ ] Verify `prefix + Left` does nothing when at leftmost pane
- [ ] Verify `prefix + Right` does nothing when at rightmost pane
- [ ] Verify same behavior for Up/Down directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)