### PR TITLE
docs: add AGENTS.md for dotfiles repository

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ P-Chan's portable dev environment as code.
   - `.editorconfig`
 - `shared/`: Shared configurations across multiple applications
   - `agents/`: Shared by Claude Code and Codex
-  - `vscode/`: Shared by VSCode and VSCode Insiders
+  - `vscode/`: Shared by VS Code and VS Code Insiders
 - `scripts/`: Scripts for dotfiles operations
 - `bin/`: Custom commands for system-wide use
 - `Brewfile`: Homebrew package definitions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# dotfiles
+
+## Project Overview
+
+P-Chan's portable dev environment as code.
+
+## Directory Structure
+
+- `home/`: Core configuration files to be symlinked to home directory with `scripts/link.sh`
+  - `.config/`:
+    - `zsh/`
+    - `tmux/`
+    - `vim/`
+    - `git/`
+    - `ghostty/`
+    - `mise/`
+    - `gh/`
+    - `karabiner/`
+    - `Code/`
+    - `Code - Insiders/`
+    - `sheldon/`
+    - `zsh-abbr/`
+    - `fixpack/`
+    - `starship.toml`
+  - `.claude/`
+  - `.codex/`
+  - `.ssh/`
+  - `.zshenv`
+  - `.editorconfig`
+- `shared/`: Shared configurations across multiple applications
+  - `agents/`: Shared by Claude Code and Codex
+  - `vscode/`: Shared by VSCode and VSCode Insiders
+- `scripts/`: Scripts for dotfiles operations
+- `bin/`: Custom commands for system-wide use
+- `Brewfile`: Homebrew package definitions
+- `code-extensions`: VSCode extensions definitions
+
+## Tech Stack
+
+- Shell scripts
+- Deno
+
+## Verification
+
+- `scripts/doctor.sh`: Check existence of required commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Why

To help Claude Code understand the dotfiles repository structure and purpose when working on it.

## What

- Added `AGENTS.md` documenting:
  - Project overview and purpose
  - Detailed directory structure (including `home/.config/` contents)
  - Tech stack (Shell scripts and Deno)
  - Verification method (`scripts/doctor.sh`)
- Added `CLAUDE.md` that references `AGENTS.md` using `@` syntax for Claude Code compatibility
- Followed best practices: kept under 60 lines, focused on WHAT/WHY/HOW structure, minimized instructions