### PR TITLE
feat(claude): disable idle notification in Notification hook

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -33,6 +33,7 @@
     ],
     "Notification": [
       {
+        "matcher": "permission_prompt",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Why

The Notification hook triggers in two cases:
1. Immediately when permission is needed (`permission_prompt`)
2. After 60 seconds of idle time (`idle_prompt`)

The 60-second idle notification was noisy and not needed, as I prefer to check Claude Code's status manually.

## What

Added `permission_prompt` matcher to the Notification hook configuration to disable the 60-second idle notifications while keeping permission request notifications active.