### PR TITLE
feat(agents): clarify background execution in `creating-gh-pr` skill

### DIFF
--- a/shared/agents/skills/creating-gh-pr/SKILL.md
+++ b/shared/agents/skills/creating-gh-pr/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: creating-gh-pr
 description: GitHub の PR を作成します。ユーザーが PR の作成を求めたときや、エージェントが PR を作成するときに使用してください。
+compatibility: Claude Code
 allowed-tools: Bash(gh-notify-checks), Bash(gh request-review-to-copilot), Bash(gh-notify-copilot-review), Bash(gh pr checks), Bash(gh run view:*), Bash(gh run rerun:*), Bash(gh get-review-comments)
 ---
 
@@ -50,9 +51,9 @@ gh pr create \
 
 以下を質問し、ユーザーが肯定した場合に実行します。
 
-1. チェックが終了したときに通知するか？ → `gh-notify-checks` をバックグラウンドで実行
+1. チェックが終了したときに通知するか？ → Bash ツールで `run_in_background: true` を指定して `gh-notify-checks` を実行
 2. Copilot にレビューをリクエストするか？ → `gh request-review-to-copilot` を実行
-3. Copilot がレビューしたときに通知するか？ → `gh-notify-copilot-review` をバックグラウンドで実行
+3. Copilot がレビューしたときに通知するか？ → Bash ツールで `run_in_background: true` を指定して `gh-notify-copilot-review` を実行
 
 ### 4. バックグラウンド処理完了後
 


### PR DESCRIPTION
## Why

The `creating-gh-pr` skill had ambiguous instructions for background execution. This update clarifies the exact method to run background commands using Claude Code's Bash tool.

## What

- Add `compatibility: Claude Code` field to explicitly mark this skill as Claude Code-specific
- Update background execution instructions to explicitly specify `run_in_background: true` parameter