### PR TITLE
feat(tmux): add automatic window renumbering

### DIFF
--- a/home/.config/tmux/tmux.conf
+++ b/home/.config/tmux/tmux.conf
@@ -14,6 +14,8 @@ bind -r Down if-shell "[ $(tmux display -p '#{pane_at_bottom}') -eq 0 ]" "select
 # Start window/pane numbering at 1
 set -g base-index 1
 set -g pane-base-index 1
+# Renumber windows when one is closed
+set -g renumber-windows on
 
 # Keybindings
 # New window (limit 9)


### PR DESCRIPTION
## Summary

Enable automatic window renumbering in tmux to maintain sequential window numbers.

## Changes

- Add `renumber-windows on` option to tmux configuration

## Motivation

When closing a window in tmux (e.g., closing window 2 when windows 1, 2, and 3 exist), the remaining windows should be renumbered sequentially (1, 2) instead of leaving gaps (1, 3). This improves window navigation and maintains consistent numbering.