### PR TITLE
feat(claude): add WebSearch permission

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -15,6 +15,7 @@
       "Bash(tail:*)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:raw.githubusercontent.com)",
+      "WebSearch",
       "Skill"
     ],
     "deny": ["Bash(sudo:*)", "Read(.env*)", "Read(!.env*.example)", "Write(.env*)", "Write(!.env*.example)"]


### PR DESCRIPTION
## Why

Enable web search functionality in Claude Code.

## What

- Add `WebSearch` to the allow list in `settings.json`