### PR TITLE
feat(vim): add system clipboard integration

### DIFF
--- a/home/.config/vim/vimrc
+++ b/home/.config/vim/vimrc
@@ -20,4 +20,4 @@ set wrapscan
 set backspace=2
 
 " Use system clipboard
-set clipboard=unnamed
+set clipboard=unnamed,unnamedplus

--- a/home/.config/vim/vimrc
+++ b/home/.config/vim/vimrc
@@ -18,3 +18,6 @@ set smartcase
 set wrapscan
 
 set backspace=2
+
+" Use system clipboard
+set clipboard=unnamed


### PR DESCRIPTION
## What

Add `clipboard=unnamed` setting to vimrc to sync the unnamed register with the system clipboard.

## Why

Enable copying text from Vim to be available in the OS clipboard for pasting in other applications.