### PR TITLE
fix(tmux): prevent status icon from persisting after Claude Code exits

### DIFF
--- a/home/.config/tmux/scripts/claude-code-status.sh
+++ b/home/.config/tmux/scripts/claude-code-status.sh
@@ -31,6 +31,8 @@ while IFS='|' read -r command title; do
   fi
   pane_titles+="$title"$'\n'
 done <<< "$pane_info"
+# Remove trailing newline
+pane_titles="${pane_titles%$'\n'}"
 
 # Only show status if Claude Code is actually running
 if [[ "$has_claude" == false ]]; then

--- a/home/.config/tmux/scripts/claude-code-status.sh
+++ b/home/.config/tmux/scripts/claude-code-status.sh
@@ -9,10 +9,31 @@ if [[ -z "$window_id" ]]; then
   exit 0
 fi
 
-# Get pane titles for the specified window
-pane_titles=$(tmux list-panes -t "$window_id" -F '#{pane_title}' 2>/dev/null)
+# Get pane info for the specified window
+pane_info=$(tmux list-panes -t "$window_id" -F '#{pane_current_command}|#{pane_title}' 2>/dev/null)
 
-if [[ -z "$pane_titles" ]]; then
+if [[ -z "$pane_info" ]]; then
+  exit 0
+fi
+
+# Check if Claude Code is actually running
+# Process name varies by installation method:
+# - Homebrew: "claude"
+# - Native: version number (e.g., "2.1.12")
+# NOTE: Native installation showing version number as process name is likely a bug
+# and may be fixed in the future: https://github.com/anthropics/claude-code/issues/12433
+has_claude=false
+pane_titles=""
+
+while IFS='|' read -r command title; do
+  if [[ "$command" == "claude" ]] || [[ "$command" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    has_claude=true
+  fi
+  pane_titles+="$title"$'\n'
+done <<< "$pane_info"
+
+# Only show status if Claude Code is actually running
+if [[ "$has_claude" == false ]]; then
   exit 0
 fi
 


### PR DESCRIPTION
## Why

After exiting Claude Code, the status icon in tmux continued to appear because the pane title was not updated.

## What

Modified the status script to check if Claude Code is actually running by inspecting the process name before displaying the status icon.

Process name detection supports both installation methods:
- Homebrew: `claude`
- Native: version number format (e.g., `2.1.12`)

## Reference

https://github.com/anthropics/claude-code/issues/12433