### PR TITLE
feat(tmux): enable OSC 8 hyperlinks for Ghostty

### DIFF
--- a/home/.config/tmux/tmux.conf
+++ b/home/.config/tmux/tmux.conf
@@ -1,6 +1,7 @@
 # True color support
 set -g default-terminal "tmux-256color"
 set -as terminal-features ",xterm-256color:RGB"
+set -as terminal-features ",xterm-ghostty:RGB:hyperlinks"
 
 # Mouse support
 set -g mouse on


### PR DESCRIPTION
## Why

OSC 8 hyperlinks were not working in tmux.

## What

Add `xterm-ghostty:RGB:hyperlinks` to `terminal-features` to enable hyperlinks for Ghostty's TERM value.