### PR TITLE
feat(homebrew): add QMK

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,10 +1,16 @@
 tap "steipete/tap"
 brew "defaultbrowser"
 brew "dockutil"
+# Required by qmk doctor but not declared as dependency in QMK formula
+# TODO: Can be removed when QMK formula adds dos2unix as a dependency
+brew "dos2unix"
 brew "eza"
 brew "git"
 brew "mise"
-brew "python"
+# qmk bottle expects python@3.13, but Homebrew installs python@3.14
+# TODO: Can be removed when https://github.com/qmk/homebrew-qmk/issues/93 is resolved
+brew "python@3.13"
+brew "qmk/qmk/qmk"
 brew "terminal-notifier"
 brew "vim"
 brew "zsh"

--- a/Brewfile
+++ b/Brewfile
@@ -2,7 +2,7 @@ tap "steipete/tap"
 brew "defaultbrowser"
 brew "dockutil"
 # Required by qmk doctor but not declared as dependency in QMK formula
-# TODO: Can be removed when QMK formula adds dos2unix as a dependency
+# TODO: Can be removed when https://github.com/qmk/homebrew-qmk/issues/97 is resolved
 brew "dos2unix"
 brew "eza"
 brew "git"

--- a/home/.config/zsh/.zshenv
+++ b/home/.config/zsh/.zshenv
@@ -13,7 +13,7 @@ export PATH="$DOTFILES_DIR/bin:$PATH"
 
 # QMK dependencies (keg-only formulae from Homebrew)
 # arm-none-eabi-gcc@8, arm-none-eabi-binutils, and avr-gcc@8 are not symlinked to PATH by default
-# TODO: Can be removed when QMK formula handles PATH configuration automatically
+# TODO: Can be removed when https://github.com/qmk/homebrew-qmk/issues/98 is resolved
 if type brew &>/dev/null; then
   BREW_PREFIX="$(brew --prefix)"
   export PATH="$BREW_PREFIX/opt/arm-none-eabi-gcc@8/bin:$PATH"

--- a/home/.config/zsh/.zshenv
+++ b/home/.config/zsh/.zshenv
@@ -11,6 +11,15 @@ export DOTFILES_DIR="${CONFIGURED_DOTFILES_DIR:-$HOME/src/github.com/p-chan/dotf
 export PATH="$HOME/.local/bin:$PATH"
 export PATH="$DOTFILES_DIR/bin:$PATH"
 
+# QMK dependencies (keg-only formulae from Homebrew)
+# arm-none-eabi-gcc@8, arm-none-eabi-binutils, and avr-gcc@8 are not symlinked to PATH by default
+# TODO: Can be removed when QMK formula handles PATH configuration automatically
+if type brew &>/dev/null; then
+  export PATH="$(brew --prefix arm-none-eabi-gcc@8)/bin:$PATH"
+  export PATH="$(brew --prefix arm-none-eabi-binutils)/bin:$PATH"
+  export PATH="$(brew --prefix avr-gcc@8)/bin:$PATH"
+fi
+
 if type mise &>/dev/null; then
   eval "$(mise env -s zsh)"
 fi

--- a/home/.config/zsh/.zshenv
+++ b/home/.config/zsh/.zshenv
@@ -15,9 +15,10 @@ export PATH="$DOTFILES_DIR/bin:$PATH"
 # arm-none-eabi-gcc@8, arm-none-eabi-binutils, and avr-gcc@8 are not symlinked to PATH by default
 # TODO: Can be removed when QMK formula handles PATH configuration automatically
 if type brew &>/dev/null; then
-  export PATH="$(brew --prefix arm-none-eabi-gcc@8)/bin:$PATH"
-  export PATH="$(brew --prefix arm-none-eabi-binutils)/bin:$PATH"
-  export PATH="$(brew --prefix avr-gcc@8)/bin:$PATH"
+  BREW_PREFIX="$(brew --prefix)"
+  export PATH="$BREW_PREFIX/opt/arm-none-eabi-gcc@8/bin:$PATH"
+  export PATH="$BREW_PREFIX/opt/arm-none-eabi-binutils/bin:$PATH"
+  export PATH="$BREW_PREFIX/opt/avr-gcc@8/bin:$PATH"
 fi
 
 if type mise &>/dev/null; then


### PR DESCRIPTION
## Summary

Add QMK keyboard firmware development environment to enable building custom keyboard firmware.

## Changes

- Add `qmk/qmk/qmk` package to Brewfile
- Add `dos2unix` with workaround comment (required by qmk doctor but missing from formula dependencies)
- Add `python@3.13` with workaround comment (qmk bottle expects 3.13 but Homebrew installs 3.14)
- Add PATH configuration for keg-only toolchains in `.zshenv` (arm-none-eabi-gcc@8, arm-none-eabi-binutils, avr-gcc@8)

All workarounds include TODO comments with removal conditions for future maintenance.

## Related Issues

- https://github.com/qmk/homebrew-qmk/issues/93