### PR TITLE
feat(claude): add `gh run list` permission

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -10,6 +10,7 @@
       "Bash(gh pr diff:*)",
       "Bash(gh pr list:*)",
       "Bash(gh pr view:*)",
+      "Bash(gh run list:*)",
       "Bash(gh run view:*)",
       "Bash(gh get-review-comments:*)",
       "Bash(tail:*)",


### PR DESCRIPTION
## Why

To avoid being prompted for permission every time the `gh run list` command is used to check the GitHub Actions workflow run list.

## What

- Add `Bash(gh run list:*)` permission to `home/.claude/settings.json`