### PR TITLE
fix(yazi): manage packages via packages.txt to avoid hash mismatch

### DIFF
--- a/home/.config/yazi/.gitignore
+++ b/home/.config/yazi/.gitignore
@@ -1,2 +1,3 @@
 plugins/
 flavors/
+package.toml

--- a/home/.config/yazi/package.toml
+++ b/home/.config/yazi/package.toml
@@ -1,7 +1,0 @@
-[[plugin.deps]]
-use = "yazi-rs/plugins:git"
-rev = "6c71385"
-hash = "36a484acf6a0a0219c543ccb4cee218f"
-
-[flavor]
-deps = []

--- a/home/.config/yazi/packages.txt
+++ b/home/.config/yazi/packages.txt
@@ -1,0 +1,1 @@
+yazi-rs/plugins:git

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -182,7 +182,10 @@ fi
 if type ya &>/dev/null; then
   log_info "Installing yazi plugins and flavors..."
 
-  ya pkg install
+  while IFS= read -r package; do
+    [[ -z "$package" || "$package" == \#* ]] && continue
+    ya pkg add "$package"
+  done < "$HOME/.config/yazi/packages.txt"
 
   log_success "Successfully installed yazi plugins and flavors."
 else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -185,7 +185,7 @@ if type ya &>/dev/null; then
   while IFS= read -r package; do
     [[ -z "$package" || "$package" == \#* ]] && continue
     ya pkg add "$package"
-  done < "$HOME/.config/yazi/packages.txt"
+  done < "$DOTFILES_DIR/home/.config/yazi/packages.txt"
 
   log_success "Successfully installed yazi plugins and flavors."
 else


### PR DESCRIPTION
## Why

`package.toml` managed by `ya pkg` contains a machine-specific `hash` field. When synced across machines via dotfiles, `ya pkg upgrade` fails with \"You have modified the contents of the plugin\" because the hash doesn't match the locally installed files.

## What

- Gitignore `package.toml` so each machine manages its own state
- Add `packages.txt` as a portable package list
- Update `install.sh` to install packages from `packages.txt` using `ya pkg add`