### PR TITLE
chore: remove Linux support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             xargs
           )" >> $GITHUB_OUTPUT
 
-  install-darwin:
+  install:
     needs: [get-cask-packages]
     runs-on: macos-15
     defaults:
@@ -46,24 +46,6 @@ jobs:
           mkdir -p "$HOME/.config/dotfiles"
           echo "$GITHUB_WORKSPACE" >> "$HOME/.config/dotfiles/dotfiles-dir"
       - name: Doctor
-        run: zsh scripts/doctor.sh
-
-  install-ubuntu:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v5
-      - name: Install
-        run: |
-          DOTFILES_DIR=$GITHUB_WORKSPACE bash scripts/install.sh
-      - name: Add DOTFILES_DIR
-        run: |
-          mkdir -p "$HOME/.config/dotfiles"
-          echo "$GITHUB_WORKSPACE" >> "$HOME/.config/dotfiles/dotfiles-dir"
-      - name: Doctor (login shell)
-        shell: zsh -l {0}
-        run: zsh scripts/doctor.sh
-      - name: Doctor (non-login shell)
-        shell: zsh {0}
         run: zsh scripts/doctor.sh
 
   check:

--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -5,7 +5,7 @@ deno = "latest"
 "github:ajeetdsouza/zoxide" = "latest"
 "github:sharkdp/bat" = "latest"
 "github:cli/cli" = "latest"
-"github:eza-community/eza" = { version = "latest", os = ["linux"] }
+"github:eza-community/eza" = "latest"
 "github:jkfran/killport" = "latest"
 "github:junegunn/fzf" = "latest"
 "github:rossmacarthur/sheldon" = "latest"
@@ -28,14 +28,6 @@ version = "latest"
 [tools."github:jqlang/jq".platforms]
 macos-x64 = { asset_pattern = "jq-macos-amd64" }
 macos-arm64 = { asset_pattern = "jq-macos-arm64" }
-linux-x64 = { asset_pattern = "jq-linux-amd64" }
-linux-x64-musl = { asset_pattern = "jq-linux-amd64" }
-linux-arm64 = { asset_pattern = "jq-linux-arm64" }
-linux-arm64-musl = { asset_pattern = "jq-linux-arm64" }
-linux-armv6 = { asset_pattern = "jq-linux-armel" }
-linux-armv6-musl = { asset_pattern = "jq-linux-armel" }
-linux-armv7 = { asset_pattern = "jq-linux-armhf" }
-linux-armv7-musl = { asset_pattern = "jq-linux-armhf" }
 
 [settings]
 experimental = true

--- a/home/Library/Application Support/Code/User/settings.json
+++ b/home/Library/Application Support/Code/User/settings.json
@@ -20,7 +20,6 @@
   "terminal.integrated.fontSize": 13,
   "terminal.integrated.macOptionIsMeta": true,
   "terminal.integrated.defaultProfile.osx": "zsh",
-  "terminal.integrated.defaultProfile.linux": "zsh",
   // Prevent confirmation prompts when handling vscode:// URLs (e.g. links in notifications).
   "security.promptForLocalFileProtocolHandling": false,
   "git.autofetch": true,

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-is_darwin() {
-  [[ "$(uname)" == "Darwin" ]]
-}
-
 log_info () {
   echo "ℹ️ $1"
 }
@@ -18,16 +14,11 @@ log_success () {
   echo "✅ $1"
 }
 
-required_commands=("zsh" "vim" "git" "mise" "deno" "node" "claude")
-darwin_required_commands=("xcode-select" "brew")
+required_commands=("zsh" "vim" "git" "mise" "deno" "node" "claude" "xcode-select" "brew")
 
 log_info "Checking required commands..."
 
 missing_commands=()
-
-if is_darwin; then
-  required_commands+=("${darwin_required_commands[@]}")
-fi
 
 for cmd in "${required_commands[@]}"; do
   if ! command -v "$cmd" &>/dev/null; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,8 +14,6 @@ log_success () {
   echo "✅ $1"
 }
 
-echo "🍎 Setting up dotfiles on macOS"
-
 DOTFILES_DIR="${DOTFILES_DIR:-$HOME/src/github.com/p-chan/dotfiles}"
 
 if ! pgrep oahd >&/dev/null; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,14 +2,6 @@
 
 set -e
 
-is_darwin() {
-  [[ "$(uname)" == "Darwin" ]]
-}
-
-is_linux() {
-  [[ "$(uname)" == "Linux" ]]
-}
-
 log_info () {
   echo "ℹ️ $1"
 }
@@ -22,42 +14,32 @@ log_success () {
   echo "✅ $1"
 }
 
-if is_darwin; then
-  echo "🍎 Setting up dotfiles on macOS"
-fi
-
-if is_linux; then
-  echo "🐧 Setting up dotfiles on Linux"
-fi
+echo "🍎 Setting up dotfiles on macOS"
 
 DOTFILES_DIR="${DOTFILES_DIR:-$HOME/src/github.com/p-chan/dotfiles}"
 
-if is_darwin; then
-  if ! pgrep oahd >&/dev/null; then
-    log_info "Installing Rosetta 2..."
+if ! pgrep oahd >&/dev/null; then
+  log_info "Installing Rosetta 2..."
 
-    sudo softwareupdate --install-rosetta --agree-to-license
+  sudo softwareupdate --install-rosetta --agree-to-license
 
-    log_success "Successfully installed Rosetta 2."
-  else
-    log_info "Rosetta 2 already installed."
-  fi
+  log_success "Successfully installed Rosetta 2."
+else
+  log_info "Rosetta 2 already installed."
 fi
 
-if is_darwin; then
-  if ! xcode-select -p &>/dev/null; then
-    log_info "Installing Command Line Tools..."
+if ! xcode-select -p &>/dev/null; then
+  log_info "Installing Command Line Tools..."
 
-    xcode-select --install
+  xcode-select --install
 
-    until xcode-select -p &>/dev/null; do
-      sleep 10
-    done
+  until xcode-select -p &>/dev/null; do
+    sleep 10
+  done
 
-    log_success "Successfully installed Command Line Tools."
-  else
-    log_info "Command Line Tools already installed."
-  fi;
+  log_success "Successfully installed Command Line Tools."
+else
+  log_info "Command Line Tools already installed."
 fi
 
 if [ ! -d "$DOTFILES_DIR" ]; then
@@ -94,74 +76,35 @@ else
   log_warn "$DOTFILES_DIR not found. Skipping dotfiles linking."
 fi
 
-if is_darwin; then
-  if ! type brew &>/dev/null; then
-    log_info "Installing Homebrew..."
+if ! type brew &>/dev/null; then
+  log_info "Installing Homebrew..."
 
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-    log_success "Successfully installed Homebrew."
-  else
-    log_info "Homebrew already installed."
-  fi;
+  log_success "Successfully installed Homebrew."
+else
+  log_info "Homebrew already installed."
 fi;
 
-if is_darwin; then
-  if [ -f /opt/homebrew/bin/brew ]; then
-    log_info "Setting up Homebrew."
+if [ -f /opt/homebrew/bin/brew ]; then
+  log_info "Setting up Homebrew."
 
-    eval "$(/opt/homebrew/bin/brew shellenv)"
+  eval "$(/opt/homebrew/bin/brew shellenv)"
 
-    log_success "Successfully set up Homebrew."
-  else
-    log_warn "/opt/homebrew/bin/brew not found. Skipping Homebrew setup."
-  fi
+  log_success "Successfully set up Homebrew."
+else
+  log_warn "/opt/homebrew/bin/brew not found. Skipping Homebrew setup."
 fi
 
-if is_darwin; then
-  if type brew &>/dev/null; then
-    log_info "Installing Homebrew packages..."
+if type brew &>/dev/null; then
+  log_info "Installing Homebrew packages..."
 
-    brew bundle --file="$DOTFILES_DIR/Brewfile"
+  brew bundle --file="$DOTFILES_DIR/Brewfile"
 
-    log_success "Successfully installed Homebrew packages."
-  else
-    log_warn "brew command not found. Skipping Homebrew package installation."
-  fi
+  log_success "Successfully installed Homebrew packages."
+else
+  log_warn "brew command not found. Skipping Homebrew package installation."
 fi
-
-if is_linux; then
-  if ! type zsh &>/dev/null; then
-    log_info "Installing zsh..."
-
-    sudo apt update
-    sudo apt install -y zsh
-
-    log_success "Successfully installed zsh."
-  else
-    log_info "zsh already installed."
-  fi;
-
-  if [ "$CI" != "true" ]; then
-    log_info "Changing default shell to zsh..."
-
-    chsh -s "$(command -v zsh)" "$(whoami)"
-
-    log_success "Successfully changed default shell to zsh (will take effect on next login)."
-  fi;
-fi;
-
-if is_linux; then
-  if ! type mise &>/dev/null; then
-    log_info "Installing mise..."
-
-    curl https://mise.run | sh
-
-    log_success "Successfully installed mise."
-  else
-    log_info "mise already installed."
-  fi;
-fi;
 
 if type mise &>/dev/null; then
   log_info "Installing mise tools..."
@@ -216,16 +159,12 @@ else
   log_info "CI environment detected. Skipping VSCode extensions import."
 fi
 
+if [ "$CI" != "true" ]; then
+  log_info "Provisioning macOS..."
 
-if is_darwin; then
-  if [ "$CI" != "true" ]; then
-    log_info "Provisioning macOS..."
+  bash "$DOTFILES_DIR/scripts/provisioning.sh"
 
-    bash "$DOTFILES_DIR/scripts/provisioning.sh"
-
-    log_success "Successfully provisioned macOS."
-  else
-    log_info "CI environment detected. Skipping macOS provisioning."
-  fi
+  log_success "Successfully provisioned macOS."
+else
+  log_info "CI environment detected. Skipping macOS provisioning."
 fi
-

--- a/scripts/link.sh
+++ b/scripts/link.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 
-is_darwin() {
-  [[ "$(uname)" == "Darwin" ]]
-}
-
-is_linux() {
-  [[ "$(uname)" == "Linux" ]]
-}
-
 dotfiles=(
   ".claude/CLAUDE.md"
   ".claude/hooks"
@@ -22,6 +14,7 @@ dotfiles=(
   ".config/gh/config.yml"
   ".config/ghostty"
   ".config/git"
+  ".config/karabiner"
   ".config/mise"
   ".config/sheldon"
   ".config/tmux"
@@ -33,24 +26,9 @@ dotfiles=(
   ".ssh"
   ".editorconfig"
   ".zshenv"
-)
-
-darwin_only_dotfiles=(
-  ".config/karabiner"
   "Library/Application Support/Code/User/keybindings.json"
   "Library/Application Support/Code/User/settings.json"
 )
-
-linux_only_dotfiles=(
-)
-
-if is_darwin; then
-  dotfiles+=("${darwin_only_dotfiles[@]}")
-fi
-
-if is_linux; then
-  dotfiles+=("${linux_only_dotfiles[@]}")
-fi
 
 if [ -z "$DOTFILES_DIR" ]; then
   echo "DOTFILES_DIR is not defined"


### PR DESCRIPTION
Removed all Linux-specific configuration and CI jobs since this dotfiles is macOS-only.

- Remove `is_linux()` / `is_darwin()` OS detection functions and conditionals from scripts
- Remove Linux-specific steps (zsh/mise installation via apt/curl) from `install.sh`
- Flatten `link.sh` by merging `darwin_only_dotfiles` into the main `dotfiles` array
- Remove `install-ubuntu` CI job and rename `install-darwin` to `install`
- Remove Linux platform entries from `mise/config.toml`
- Remove `terminal.integrated.defaultProfile.linux` from VS Code settings