### PR TITLE
fix(claude): replace deprecated :* syntax with space wildcard in permissions

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -2,24 +2,24 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
-      "Bash(git log:*)",
-      "Bash(gh release view:*)",
-      "Bash(gh repo view:*)",
-      "Bash(gh issue view:*)",
-      "Bash(gh pr checks:*)",
-      "Bash(gh pr diff:*)",
-      "Bash(gh pr list:*)",
-      "Bash(gh pr view:*)",
-      "Bash(gh run list:*)",
-      "Bash(gh run view:*)",
-      "Bash(gh get-review-comments:*)",
-      "Bash(tail:*)",
+      "Bash(git log *)",
+      "Bash(gh release view *)",
+      "Bash(gh repo view *)",
+      "Bash(gh issue view *)",
+      "Bash(gh pr checks *)",
+      "Bash(gh pr diff *)",
+      "Bash(gh pr list *)",
+      "Bash(gh pr view *)",
+      "Bash(gh run list *)",
+      "Bash(gh run view *)",
+      "Bash(gh get-review-comments *)",
+      "Bash(tail *)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:raw.githubusercontent.com)",
       "WebSearch",
       "Skill"
     ],
-    "deny": ["Bash(sudo:*)", "Read(.env*)", "Read(!.env*.example)", "Write(.env*)", "Write(!.env*.example)"]
+    "deny": ["Bash(sudo *)", "Read(.env*)", "Read(!.env*.example)", "Write(.env*)", "Write(!.env*.example)"]
   },
   "hooks": {
     "Notification": [


### PR DESCRIPTION
## Why

The `:*` suffix syntax in Claude Code permission rules is deprecated. The recommended syntax uses a space before `*` (e.g., `git log *` instead of `git log:*`).

## What

- Replace all `command:*` patterns with `command *` in `home/.claude/settings.json`