### PR TITLE
fix(claude): deny `git -C` to prevent permission bypass

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -19,7 +19,14 @@
       "WebSearch",
       "Skill"
     ],
-    "deny": ["Bash(sudo *)", "Read(.env*)", "Read(!.env*.example)", "Write(.env*)", "Write(!.env*.example)"]
+    "deny": [
+      "Bash(git -C *)",
+      "Bash(sudo *)",
+      "Read(.env*)",
+      "Read(!.env*.example)",
+      "Write(.env*)",
+      "Write(!.env*.example)"
+    ]
   },
   "hooks": {
     "Notification": [


### PR DESCRIPTION
## Why

`git -C <path>` bypasses Claude Code's permission rules. For example, `Bash(git log *)` does not match `git -C /path log`, so permission prompts appear unexpectedly.

## What

Add `Bash(git -C *)` to the `deny` list in `settings.json` to block the option entirely.