### PR TITLE
feat(claude): allow `gh issue list` permission

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -5,6 +5,7 @@
       "Bash(git log *)",
       "Bash(gh release view *)",
       "Bash(gh repo view *)",
+      "Bash(gh issue list *)",
       "Bash(gh issue view *)",
       "Bash(gh pr checks *)",
       "Bash(gh pr diff *)",


### PR DESCRIPTION
Allow `gh issue list` in Claude Code settings to enable listing GitHub issues without manual approval.