### PR TITLE
refactor(agents): replace get-allowed-merge-methods alias with gh repo view

### DIFF
--- a/home/.agents/AGENTS.md
+++ b/home/.agents/AGENTS.md
@@ -17,7 +17,6 @@
 | `get-review-comments`                          | レビューコメントを取得する。         |                                            |
 | `reply-review-comment <commentId> <replyBody>` | レビューコメントに返信する。         |                                            |
 | `resolve-review-thread <threadId>`             | レビュースレッドを解決する。         | `threadId` は `PRRT_` から始まる ID です。 |
-| `get-allowed-merge-methods`                    | 許可されているマージ方法を取得する。 |                                            |
 
 ### `gh-notify-*` コマンドリファレンス
 

--- a/home/.agents/skills/personal-merging-gh-pr/SKILL.md
+++ b/home/.agents/skills/personal-merging-gh-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: personal-merging-gh-pr
 description: ユーザーが PR のマージを求めたときや、エージェントが PR をマージするときに必ず使用してください。
-allowed-tools: Bash(gh get-review-comments), Bash(gh pr checks), Bash(gh get-allowed-merge-methods)
+allowed-tools: Bash(gh get-review-comments), Bash(gh pr checks), Bash(gh repo view)
 ---
 
 # GitHub PR マージ
@@ -22,7 +22,11 @@ allowed-tools: Bash(gh get-review-comments), Bash(gh pr checks), Bash(gh get-all
 
 ### マージ方法を確認する
 
-`gh get-allowed-merge-methods` で許可されているマージ方法を取得します。
+以下を実行して許可されているマージ方法を取得します。
+
+```bash
+gh repo view --json mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed
+```
 
 許可されているマージ方法が 1 つだけの場合、それを使用します。
 許可されているマージ方法が複数の場合、ユーザーにどれを使うか質問します。

--- a/home/.agents/skills/personal-merging-gh-pr/SKILL.md
+++ b/home/.agents/skills/personal-merging-gh-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: personal-merging-gh-pr
 description: ユーザーが PR のマージを求めたときや、エージェントが PR をマージするときに必ず使用してください。
-allowed-tools: Bash(gh get-review-comments), Bash(gh pr checks), Bash(gh repo view)
+allowed-tools: Bash(gh get-review-comments), Bash(gh pr checks), Bash(gh repo view *)
 ---
 
 # GitHub PR マージ

--- a/home/.config/gh/config.yml
+++ b/home/.config/gh/config.yml
@@ -9,5 +9,3 @@ aliases:
   reply-review-comment: '!gh api -X POST "repos/{owner}/{repo}/pulls/$(gh pr view --json number -q .number)/comments/$1/replies" -f body="$2"'
   # $1: thread ID (PRRT_...)
   resolve-review-thread: 'api graphql -f query=''mutation($threadId: ID!) { resolveReviewThread(input: {threadId: $threadId}) { thread { id isResolved } } }'' -f threadId="$1"'
-  # No args
-  get-allowed-merge-methods: '!gh api repos/{owner}/{repo} --jq "{allow_merge_commit, allow_squash_merge, allow_rebase_merge}"'


### PR DESCRIPTION
## Why

`get-allowed-merge-methods` was a wrapper around `gh api`, but the same information can be retrieved with `gh repo view`, making the alias unnecessary.

## What

- Remove `get-allowed-merge-methods` alias from `gh` config
- Replace `gh get-allowed-merge-methods` with `gh repo view --json mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed` in `personal-merging-gh-pr` skill
- Remove `get-allowed-merge-methods` entry from alias reference table in `AGENTS.md`