### PR TITLE
feat(claude): allow `WebFetch` for `docs.github.com`

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -25,6 +25,7 @@
       "Bash(gh run view *)",
       "Bash(gh get-review-comments)",
       "Bash(tail *)",
+      "WebFetch(domain:docs.github.com)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:raw.githubusercontent.com)",
       "WebSearch",


### PR DESCRIPTION
## Why

Added to allow WebFetch to `docs.github.com`.

## What

- Add `WebFetch(domain:docs.github.com)` to `home/.claude/settings.json`