### PR TITLE
fix(tmux): replace version number with claude in window name

### DIFF
--- a/home/.config/tmux/scripts/claude-code-status.sh
+++ b/home/.config/tmux/scripts/claude-code-status.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # Claude Code status indicator for tmux window
-# Usage: claude-code-status.sh <window_id>
+# Usage: claude-code-status.sh <window_id> <window_name>
 
 window_id="${1:-}"
+window_name="${2:-}"
 
 if [[ -z "$window_id" ]]; then
+  printf '%s' "$window_name"
   exit 0
 fi
 
@@ -13,6 +15,7 @@ fi
 pane_info=$(tmux list-panes -t "$window_id" -F '#{pane_current_command}|#{pane_title}' 2>/dev/null)
 
 if [[ -z "$pane_info" ]]; then
+  printf '%s' "$window_name"
   exit 0
 fi
 
@@ -36,7 +39,14 @@ pane_titles="${pane_titles%$'\n'}"
 
 # Only show status if Claude Code is actually running
 if [[ "$has_claude" == false ]]; then
+  printf '%s' "$window_name"
   exit 0
+fi
+
+# Replace version number with "claude" in window name
+display_name="$window_name"
+if [[ "$window_name" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  display_name="claude"
 fi
 
 # Check for Claude Code status
@@ -45,10 +55,12 @@ fi
 if [[ "$pane_titles" =~ [⠐⠂] ]]; then
   # Alternate between ⠐ and ⠂ based on current second
   if (( $(date +%s) % 2 == 0 )); then
-    printf ' ⠐'
+    printf '%s ⠐' "$display_name"
   else
-    printf ' ⠂'
+    printf '%s ⠂' "$display_name"
   fi
 elif [[ "$pane_titles" == *✳* ]]; then
-  printf ' ✳'  # Idle
+  printf '%s ✳' "$display_name"
+else
+  printf '%s' "$display_name"
 fi

--- a/home/.config/tmux/tmux.conf
+++ b/home/.config/tmux/tmux.conf
@@ -34,8 +34,8 @@ bind L swap-window -t +1\; select-window -t +1
 set -g status-interval 1
 set -g status-position top
 set -g status-style 'bg=default,fg=white'
-set -g window-status-format '  #I:#W#(~/.config/tmux/scripts/claude-code-status.sh #I)  '
-set -g window-status-current-format '  #I:#W#(~/.config/tmux/scripts/claude-code-status.sh #I)  '
+set -g window-status-format '  #I:#(~/.config/tmux/scripts/claude-code-status.sh #I #W)  '
+set -g window-status-current-format '  #I:#(~/.config/tmux/scripts/claude-code-status.sh #I #W)  '
 set -g window-status-current-style 'bg=#3e4452,fg=brightwhite'
 set -g status-right '#{pane_title}'
 


### PR DESCRIPTION
When Claude Code is installed natively, the process name is the version number (e.g., `2.1.62`), causing the tab name to show the version number instead of `claude`.

Pass the window name to `claude-code-status.sh` and replace the version number with `claude` in the output.