### PR TITLE
feat(yazi): enable preview text wrapping

### DIFF
--- a/home/.config/yazi/yazi.toml
+++ b/home/.config/yazi/yazi.toml
@@ -2,6 +2,9 @@
 show_hidden = true
 ratio = [1, 2, 5]
 
+[preview]
+wrap = "yes"
+
 [[plugin.prepend_fetchers]]
 id  = "git"
 url = "*"


### PR DESCRIPTION
Enable text wrapping in the preview panel by adding `wrap = "yes"` to the `[preview]` section.