### PR TITLE
feat(agents): add personal-use-opensrc skill

### DIFF
--- a/home/.agents/skills/personal-use-opensrc/SKILL.md
+++ b/home/.agents/skills/personal-use-opensrc/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: personal-use-opensrc
+description: opensrc を利用して npm パッケージや GitHub リポジトリのコードを取得して確認します。 ユーザーが npm パッケージや GitHub リポジトリのコードの確認を求めたときや、エージェントが他の npm パッケージや GitHub リポジトリのコードを参照したほうがいいと判断したときに使います。
+---
+
+# [opensrc](https://github.com/vercel-labs/opensrc) を利用する
+
+## 新しく取得する
+
+新しく取得するときは、以下のコマンドを実行します。
+
+```sh
+# npm package (e.g., `opensrc 2ch-trip`)
+opensrc <package>
+
+# GitHub repository (e.g., `opensrc p-chan/dotfiles`)
+opensrc <owner>/<repo>
+```
+
+取得したコードは、リポジトリルートの `opensrc` ディレクトリに保存されます。
+
+> [!WARNING]
+> 初回実行時はファイルの変更の許可を求めるプロンプトが表示されます。
+> その場合は、一度コマンドの実行を中止して、`--modify=false` オプションを付けて、再度コマンドを実行します。
+
+## 取得した npm パッケージや GitHub リポジトリの一覧を確認する
+
+一覧を確認するときは、以下のコマンドを実行します。
+
+```sh
+opensrc list
+```
+
+## その他
+
+その他、詳細は `opensrc -h` で確認できます。

--- a/home/.agents/skills/personal-use-opensrc/SKILL.md
+++ b/home/.agents/skills/personal-use-opensrc/SKILL.md
@@ -22,6 +22,11 @@ opensrc <owner>/<repo>
 > [!WARNING]
 > 初回実行時はファイルの変更の許可を求めるプロンプトが表示されます。
 > その場合は、一度コマンドの実行を中止して、`--modify=false` オプションを付けて、再度コマンドを実行します。
+>
+> ```sh
+> opensrc --modify=false <package>
+> opensrc --modify=false <owner>/<repo>
+> ```
 
 ## 取得した npm パッケージや GitHub リポジトリの一覧を確認する
 

--- a/home/.config/git/ignore
+++ b/home/.config/git/ignore
@@ -3,3 +3,6 @@
 
 # Windows
 Thumbs.db
+
+# Others
+opensrc

--- a/home/.config/git/ignore
+++ b/home/.config/git/ignore
@@ -5,4 +5,4 @@
 Thumbs.db
 
 # Others
-opensrc
+opensrc/

--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -19,6 +19,7 @@ deno = "latest"
 "npm:editorconfig-checker" = "latest"
 "npm:fixpack" = "latest"
 "npm:npmrc" = "latest"
+"npm:opensrc" = "latest"
 "npm:pnpm" = "latest"
 "npm:yarn" = "latest"
 


### PR DESCRIPTION
## Why

To share the workflow for referencing npm packages and GitHub repositories using `opensrc` as a skill.

## What

- Add `personal-use-opensrc` skill
- Add `npm:opensrc` to mise managed tools
- Add `opensrc` directory to gitignore