### PR TITLE
feat(claude): set model to sonnet

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -64,6 +64,7 @@
       }
     ]
   },
+  "model": "sonnet",
   "statusLine": {
     "type": "command",
     "command": "bash ~/.claude/statusline.sh"


### PR DESCRIPTION
## Summary

- Set `model` to `"sonnet"` alias instead of the full version name (e.g. `claude-sonnet-4-6`)
- Using the alias avoids the need to update the setting on every minor version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)