### PR TITLE
fix(vscode): update shift+enter keybinding sequence

### DIFF
--- a/home/Library/Application Support/Code/User/keybindings.json
+++ b/home/Library/Application Support/Code/User/keybindings.json
@@ -72,7 +72,7 @@
     "key": "shift+enter",
     "command": "workbench.action.terminal.sendSequence",
     "args": {
-      "text": "\\\r\n"
+      "text": "\u001b\r"
     },
     "when": "terminalFocus"
   },


### PR DESCRIPTION
## Why

Claude Code update changed the key sequence for Shift+Enter, causing it to send the message immediately instead of inserting a newline.

## What

Update the `shift+enter` keybinding `text` value from `\\r\n` to `\u001b\r` in `keybindings.json`.