### PR TITLE
feat(claude): add opensrc permission

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -25,6 +25,7 @@
       "Bash(gh run view *)",
       "Bash(gh review-comment list)",
       "Bash(gh review-comment list *)",
+      "Bash(opensrc *)",
       "Bash(tail *)",
       "WebFetch(domain:docs.github.com)",
       "WebFetch(domain:github.com)",


### PR DESCRIPTION
Add `Bash(opensrc *)` to the allow list in `.claude/settings.json` to permit the `opensrc` command used by the personal-use-opensrc skill.