### PR TITLE
feat(claude): add gh release list permission

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -4,6 +4,8 @@
     "allow": [
       "Bash(git log)",
       "Bash(git log *)",
+      "Bash(gh release list)",
+      "Bash(gh release list *)",
       "Bash(gh release view)",
       "Bash(gh release view *)",
       "Bash(gh repo view)",


### PR DESCRIPTION
Add `gh release list` and `gh release list *` to the allowed permissions so release listing commands can be used without manual approval.