### PR TITLE
fix: run hash -r after mise up to fix gh not found

### DIFF
--- a/bin/dots
+++ b/bin/dots
@@ -9,6 +9,7 @@ dots_up() {
 
   echo "\nUpdating mise..."
   mise up
+  hash -r
 
   echo "\nUpdating yazi plugins and flavors..."
   ya pkg upgrade


### PR DESCRIPTION
After mise updates a tool, zsh's command hash cache becomes stale, causing `gh` to be not found in subsequent commands.