### PR TITLE
feat(claude): add WebFetch permissions for qiita.com and zenn.dev

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -31,7 +31,9 @@
       "Bash(tail *)",
       "WebFetch(domain:docs.github.com)",
       "WebFetch(domain:github.com)",
+      "WebFetch(domain:qiita.com)",
       "WebFetch(domain:raw.githubusercontent.com)",
+      "WebFetch(domain:zenn.dev)",
       "WebSearch",
       "Skill"
     ],


### PR DESCRIPTION
## Why

Allow access to qiita.com and zenn.dev to reference technical articles.

## What

- Add `WebFetch(domain:qiita.com)` to the allow list
- Add `WebFetch(domain:zenn.dev)` to the allow list