### PR TITLE
fix(mise): use shims to resolve commands after mise up

### DIFF
--- a/bin/dots
+++ b/bin/dots
@@ -9,7 +9,6 @@ dots_up() {
 
   echo "\nUpdating mise..."
   mise up
-  hash -r
 
   echo "\nUpdating yazi plugins and flavors..."
   ya pkg upgrade

--- a/home/.config/zsh/.zshenv
+++ b/home/.config/zsh/.zshenv
@@ -22,7 +22,9 @@ if type brew &>/dev/null; then
 fi
 
 if type mise &>/dev/null; then
+  # Set PATH and mise-managed env vars
   eval "$(mise env -s zsh)"
+  # Prepend shims to PATH so commands resolve correctly after `mise up`
   eval "$(mise activate zsh --shims)"
 fi
 

--- a/home/.config/zsh/.zshenv
+++ b/home/.config/zsh/.zshenv
@@ -23,6 +23,7 @@ fi
 
 if type mise &>/dev/null; then
   eval "$(mise env -s zsh)"
+  eval "$(mise activate zsh --shims)"
 fi
 
 if [[ -f "${ZDOTDIR:-$HOME}/.zshenv.local" ]]; then


### PR DESCRIPTION
## Why

`mise up` updates tools to new versions, but existing shell sessions still have version-specific paths (e.g. `~/.local/share/mise/installs/gh/2.88.1/bin`) in PATH. When the old version directory is removed, commands become `not found`.

## What

- Add `eval "$(mise activate zsh --shims)"` to `.zshenv` so that non-interactive shells (e.g. Claude Code) resolve commands via shims, which dynamically pick the correct binary at runtime
- Remove the `hash -r` workaround in `bin/dots` as it is no longer needed