### PR TITLE
feat(claude): deny git add -A in settings

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -39,6 +39,7 @@
     ],
     "deny": [
       "Bash(git -C *)",
+      "Bash(git add -A)",
       "Bash(sudo *)",
       "Read(.env*)",
       "Read(!.env*.example)",


### PR DESCRIPTION
## Summary

- Add `Bash(git add -A)` to the deny list in Claude Code settings
- Prevents Claude from using `git add -A` which can accidentally stage sensitive files or large binaries