### PR TITLE
feat(vscode): exclude opensrc from search

### DIFF
--- a/home/Library/Application Support/Code/User/settings.json
+++ b/home/Library/Application Support/Code/User/settings.json
@@ -17,6 +17,9 @@
   },
   "workbench.colorTheme": "One Dark Pro",
   "workbench.iconTheme": "file-icons",
+  "search.exclude": {
+    "**/opensrc": true
+  },
   "terminal.integrated.fontSize": 13,
   "terminal.integrated.macOptionIsMeta": true,
   "terminal.integrated.defaultProfile.osx": "zsh",


### PR DESCRIPTION
## What

- Add `search.exclude` setting to VSCode configuration to exclude `**/opensrc` directories from search results