### PR TITLE
feat(claude): add figma-desktop MCP read-only permissions to settings

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -38,7 +38,13 @@
       "WebFetch(domain:raw.githubusercontent.com)",
       "WebFetch(domain:zenn.dev)",
       "WebSearch",
-      "Skill"
+      "Skill",
+      "mcp__figma-desktop__get_code_connect_map",
+      "mcp__figma-desktop__get_code_connect_suggestions",
+      "mcp__figma-desktop__get_design_context",
+      "mcp__figma-desktop__get_metadata",
+      "mcp__figma-desktop__get_screenshot",
+      "mcp__figma-desktop__get_variable_defs"
     ],
     "deny": [
       "Bash(git -C *)",


### PR DESCRIPTION
Add allow permissions for the read-only tools of the figma-desktop MCP server to `settings.json`.

## What

Added the following `mcp__figma-desktop__*` permissions to the allow list (alphabetical order):

- `get_code_connect_map`
- `get_code_connect_suggestions`
- `get_design_context`
- `get_metadata`
- `get_screenshot`
- `get_variable_defs`

Write-only tools (`add_code_connect_map`, `send_code_connect_mappings`, `create_design_system_rules`) and `get_figjam` are excluded.
