### PR TITLE
feat(claude): add node_modules rule to use opensrc

### DIFF
--- a/home/.claude/rules/node-modules.md
+++ b/home/.claude/rules/node-modules.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - node_modules/**
+---
+
+# node_modules
+
+`node_modules` 以下のコードを参照するときは、積極的に [opensrc](https://github.com/vercel-labs/opensrc) を利用します。


### PR DESCRIPTION
## Why

When referencing code under `node_modules`, using [opensrc](https://github.com/vercel-labs/opensrc) is more efficient than reading files directly.

## What

Add `home/.claude/rules/node-modules.md` with a rule that encourages using opensrc when referencing code under `node_modules`.