### PR TITLE
feat(agents): improve git branch skill

### DIFF
--- a/home/.agents/skills/personal-creating-git-branch/SKILL.md
+++ b/home/.agents/skills/personal-creating-git-branch/SKILL.md
@@ -1,58 +1,40 @@
 ---
 name: personal-creating-git-branch
 description: Git リポジトリの慣習に則って新しいブランチを作成します。ユーザーがブランチの作成を求めたときや、エージェントがブランチを作成するときに必ず使用してください。
-allowed-tools: Bash(git branch:*), Bash(grep:*), Bash(head:*), Bash(sed:*), Bash(cut:*), Bash(sort:*), Bash(xargs:*)
+allowed-tools: Bash(git status), Bash(git status *), Bash(git diff), Bash(git diff *)
 ---
 
 # Git ブランチ作成
 
 ## 前提
 
-`README.md` やメモリファイル（`AGENTS.md` や `CLAUDE.md` など）にブランチ名の規約がある場合、それに従う。
-
-以下のワークフローは、明確な規約がない場合に実行します。
+メモリファイル（`AGENTS.md` や `CLAUDE.md` など）にブランチ名の規約がある場合は、メモリファイルに従う。
 
 ## ワークフロー
 
 ### 1. 情報収集
 
-既存のブランチ名を取得：
+今までのコンテキストをもとに、ブランチの目的を理解します。
 
-```bash
-git branch --sort=-committerdate | grep -v -E '^\*?\s*(main|master)\s*$' | head -10
-```
+コンテキストが不足している場合は `git status` や `git diff` で情報収集して、ブランチの目的を理解します。
 
-### 2. 判定
+### 2. ブランチ名生成
 
-#### スタイル判定
+ブランチの目的をもとに 2〜5 単語程度のブランチ名を生成します。
 
-既存ブランチから以下を判定します。
+- 動詞で始める（`add`、`update`、`fix`、`remove` など）
+- スラッシュを使わない
+- ハイフンで区切る
+- 変更内容を簡潔に表現する
 
-- **シンプル形式**: `add-feature`、`fix-bug` などスラッシュなし
-- **プレフィックス付き**: `feature/xxx`、`fix/xxx` などスラッシュを含む
+**例**
 
-##### 例外
+- add-foo
+- fix-bar
+- update-baz
+- remove-qux
 
-- 複数スタイルが混在する場合、最も使用頻度の高いスタイルを採用
-- 既存ブランチがない場合は、どのスタイルを使用するかユーザーに確認
-
-#### プレフィックス判定
-
-プレフィックス付きスタイルの場合、以下のコマンドでプレフィックス一覧を取得します：
-
-```bash
-git branch --all | head -100 | grep -v -E 'HEAD|main\s*$|master\s*$' | sed -E 's/^\*?\s*//; s|remotes/origin/||' | grep '/' | cut -d'/' -f1 | sort -u | xargs | sed 's/ /, /g'
-```
-
-### 3. ブランチ名生成
-
-判定したスタイルに基づき、2〜5 単語程度のブランチ名を生成します。
-
-- 動詞始まり（`add`、`update`、`fix`、`remove` など）
-- ハイフン区切り
-- 変更内容を簡潔に表現
-
-### 4. ブランチ作成
+### 3. ブランチ作成
 
 生成されたブランチ名を表示し、ブランチを作成します。
 


### PR DESCRIPTION
## What

- Replace `allowed-tools` with `git status` and `git diff` instead of `git branch`, `grep`, etc.
- Remove style detection logic (slash vs no-slash prefix) — always use hyphen-only format
- Add explicit rule: no slashes in branch names
- Add fallback to `git status` / `git diff` when context is insufficient