### PR TITLE
feat(agents): warn against using --repo with personal-merging-gh-pr skill

### DIFF
--- a/home/.agents/skills/personal-merging-gh-pr/SKILL.md
+++ b/home/.agents/skills/personal-merging-gh-pr/SKILL.md
@@ -48,4 +48,4 @@ gh repo view --json mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed
 また `--delete-branch` オプションを付けてマージと同時にブランチを削除します（このオプションを使うと、自動でベースブランチに切り替わります）。
 
 > [!WARNING]
-> `--repo` オプションは `--delete-branch` オプションを無効化するため、他リポジトリの PR をマージするとき以外は使用しません。
+> `--repo` オプションは `--delete-branch` オプションを無効化するため、他リポジトリの PR をマージするときに限り、使用します。

--- a/home/.agents/skills/personal-merging-gh-pr/SKILL.md
+++ b/home/.agents/skills/personal-merging-gh-pr/SKILL.md
@@ -46,3 +46,6 @@ gh repo view --json mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed
 - Squash: `--squash` オプション
 
 また `--delete-branch` オプションを付けてマージと同時にブランチを削除します（このオプションを使うと、自動でベースブランチに切り替わります）。
+
+> [!WARNING]
+> `--repo` オプションは `--delete-branch` オプションを無効化するため、他リポジトリの PR をマージするとき以外は使用しません。


### PR DESCRIPTION
## Why

Using `--repo` option with `gh pr merge` silently disables `--delete-branch`, causing unintended behavior where the branch is not deleted after merging.

## What

Added a WARNING note to the `personal-merging-gh-pr` skill to avoid using `--repo` option.

## Notes

Exception is documented for cases where `--repo` is genuinely needed (e.g., merging a PR from another repository).