### PR TITLE
feat(claude): set language to japanese and enable voice

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -88,5 +88,7 @@
     "example-skills@anthropic-agent-skills": true
   },
   "alwaysThinkingEnabled": true,
+  "language": "japanese",
+  "voiceEnabled": true,
   "autoMemoryEnabled": false
 }


### PR DESCRIPTION
## Why

Configure language and voice settings in Claude Code.

## What

- Set `language` to `japanese`
- Set `voiceEnabled` to `true`

## Notes