### PR TITLE
fix(agents): restrict git config permission to --local --get in skills

### DIFF
--- a/home/.agents/skills/personal-creating-gh-pr/SKILL.md
+++ b/home/.agents/skills/personal-creating-gh-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: personal-creating-gh-pr
 description: GitHub の PR を作成します。ユーザーが PR の作成を求めたときや、エージェントが PR を作成するときに使用してください。
 compatibility: Claude Code
-allowed-tools: Bash(git config *), Bash(gh pr list *), Bash(git ls-remote *)
+allowed-tools: Bash(git config --local --get *), Bash(gh pr list *), Bash(git ls-remote *)
 ---
 
 # GitHub PR 作成
@@ -16,8 +16,8 @@ allowed-tools: Bash(git config *), Bash(gh pr list *), Bash(git ls-remote *)
 まず以下のコマンドでキャッシュを確認します：
 
 ```bash
-git config --local --get convention.language 2>/dev/null || true
-git config --local --get convention.pull-request-title 2>/dev/null || true
+git config --local --get convention.language
+git config --local --get convention.pull-request-title
 ```
 
 両方設定済みの場合はその値を使い、言語判定とスタイル判定をスキップします。

--- a/home/.agents/skills/personal-creating-git-commit/SKILL.md
+++ b/home/.agents/skills/personal-creating-git-commit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: personal-creating-git-commit
 description: Git リポジトリのスタイルに合わせてコミットを作成します。ユーザーがコミットを求めたときや、エージェントがコミットするときに必ず使用してください。
-allowed-tools: Bash(git diff:*), Bash(git log:*), Bash(git config:*), Bash(sed:*), Bash(tr:*), Bash(sort:*), Bash(xargs:*)
+allowed-tools: Bash(git diff:*), Bash(git log:*), Bash(git config --local --get *), Bash(sed:*), Bash(tr:*), Bash(sort:*), Bash(xargs:*)
 ---
 
 # Git コミット作成
@@ -37,8 +37,8 @@ git diff
 まず以下のコマンドでキャッシュを確認します：
 
 ```bash
-git config --local --get convention.language 2>/dev/null || true
-git config --local --get convention.commit-message 2>/dev/null || true
+git config --local --get convention.language
+git config --local --get convention.commit-message
 ```
 
 両方設定済みの場合はその値を使い、言語判定とスタイル判定をスキップします。


### PR DESCRIPTION
## Why

The `git config` permission was too broad, allowing unintended git config operations.

## What

- Restrict `allowed-tools` for `git config` to `git config --local --get` in `personal-creating-git-commit` and `personal-creating-gh-pr` skills
- Remove `2>/dev/null || true` from cache check commands for simplicity

## Notes