### PR TITLE
fix(homebrew): add QMK dependency taps

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,6 @@
+tap "osx-cross/arm"
+tap "osx-cross/avr"
+tap "qmk/qmk"
 tap "steipete/tap"
 brew "defaultbrowser"
 brew "dockutil"


### PR DESCRIPTION
## Why

GitHub Actions logs emitted a non-fatal Homebrew runtime dependency warning while resolving `qmk/qmk/qmk`.
Adding the related taps explicitly should make dependency resolution more predictable in clean CI environments.

## What

- add `osx-cross/arm` tap to `Brewfile`
- add `osx-cross/avr` tap to `Brewfile`
- add `qmk/qmk` tap to `Brewfile`

## Notes

This change only makes the tap dependencies explicit for Homebrew.