### PR TITLE
feat(claude): add CLAUDE_CODE_NO_FLICKER env variable

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -91,5 +91,8 @@
   "language": "japanese",
   "voiceEnabled": true,
   "feedbackSurveyRate": 0,
-  "autoMemoryEnabled": false
+  "autoMemoryEnabled": false,
+  "env": {
+    "CLAUDE_CODE_NO_FLICKER": "1"
+  }
 }


### PR DESCRIPTION
## Why

Prevent flickering in Claude Code by setting `CLAUDE_CODE_NO_FLICKER`.

## What

- Add `CLAUDE_CODE_NO_FLICKER=1` to `env` in `home/.claude/settings.json`

## Notes

N/A
