### PR TITLE
feat(claude): split statusline into two lines

### DIFF
--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Claude Code statusline
-# Format: currentDir on branchName (#PR1, #PR2) | Model: <model> | Context: <pct>% | 5h: <pct>% (<time>) | 7d: <pct>% (<time>)
+# Format: currentDir on branchName (#PR1, #PR2)
+#         Model: <model> | Context: <pct>% | 5h: <pct>% (<time>) | 7d: <pct>% (<time>)
 
 # Read JSON input from stdin (if available)
 input=$(cat 2>/dev/null || echo '{}')
@@ -153,7 +154,8 @@ fi
 
 # Model
 if [[ -n "$model" && "$model" != "null" ]]; then
-  output+=" ${GRAY}|${RESET} Model: ${ORANGE}${model}${RESET}"
+  output+=$'\n'
+  output+="Model: ${ORANGE}${model}${RESET}"
 fi
 
 # Context usage

--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -1,5 +1,4 @@
 font-family = "Source Han Code JP"
-font-family = "Symbols Nerd Font Mono"
 font-feature = -calt
 font-feature = -liga
 font-feature = -dlig

--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -1,4 +1,5 @@
 font-family = "Source Han Code JP"
+font-family = "Symbols Nerd Font Mono"
 font-feature = -calt
 font-feature = -liga
 font-feature = -dlig


### PR DESCRIPTION
## Why

The statusline was getting too long when model and rate limit info were on the same line as the directory and branch.

## What

- Move Model and usage info to the second line in `statusline.sh`

## Notes

N/A