### PR TITLE
chore(homebrew,zsh): remove qmk

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,16 +1,9 @@
 tap "steipete/tap"
 brew "defaultbrowser"
 brew "dockutil"
-# Required by qmk doctor but not declared as dependency in QMK formula
-# TODO: Can be removed when https://github.com/qmk/homebrew-qmk/issues/97 is resolved
-brew "dos2unix"
 brew "eza"
 brew "git"
 brew "mise"
-# qmk bottle expects python@3.13, but Homebrew installs python@3.14
-# TODO: Can be removed when https://github.com/qmk/homebrew-qmk/issues/93 is resolved
-brew "python@3.13"
-brew "qmk/qmk/qmk"
 brew "tailscale"
 brew "terminal-notifier"
 brew "vim"

--- a/home/.config/zsh/.zshenv
+++ b/home/.config/zsh/.zshenv
@@ -11,16 +11,6 @@ export DOTFILES_DIR="${CONFIGURED_DOTFILES_DIR:-$HOME/src/github.com/p-chan/dotf
 export PATH="$HOME/.local/bin:$PATH"
 export PATH="$DOTFILES_DIR/bin:$PATH"
 
-# QMK dependencies (keg-only formulae from Homebrew)
-# arm-none-eabi-gcc@8, arm-none-eabi-binutils, and avr-gcc@8 are not symlinked to PATH by default
-# TODO: Can be removed when https://github.com/qmk/homebrew-qmk/issues/98 is resolved
-if type brew &>/dev/null; then
-  BREW_PREFIX="$(brew --prefix)"
-  export PATH="$BREW_PREFIX/opt/arm-none-eabi-gcc@8/bin:$PATH"
-  export PATH="$BREW_PREFIX/opt/arm-none-eabi-binutils/bin:$PATH"
-  export PATH="$BREW_PREFIX/opt/avr-gcc@8/bin:$PATH"
-fi
-
 if type mise &>/dev/null; then
   # Set PATH and mise-managed env vars
   eval "$(mise env -s zsh)"


### PR DESCRIPTION
## Why

No longer using QMK.

## What

- Remove `qmk/qmk/qmk`, `dos2unix`, `python@3.13` and related comments from `Brewfile`
- Remove QMK keg-only PATH configuration from `home/.config/zsh/.zshenv`

## Notes

N/A