### PR TITLE
perf(homebrew): use --jobs=auto for brew bundle

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -97,7 +97,7 @@ fi
 if type brew &>/dev/null; then
   log_info "Installing Homebrew packages..."
 
-  brew bundle --file="$DOTFILES_DIR/Brewfile"
+  brew bundle --file="$DOTFILES_DIR/Brewfile" --jobs=auto
 
   log_success "Successfully installed Homebrew packages."
 else


### PR DESCRIPTION
## Why

To speed up `brew bundle` installation by parallelizing it.

## What

Add `--jobs=auto` option to `brew bundle` command.

## Notes

-