### PR TITLE
feat(claude): add dirty indicator to statusline

### DIFF
--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -41,7 +41,7 @@ else
   current_dir=$(basename "$PWD")
 fi
 
-# Get Git branch and diff stats
+# Get Git branch and dirty state
 git_branch=""
 git_diff=""
 if git rev-parse --git-dir >/dev/null 2>&1; then

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Claude Code statusline
-# Format: currentDir on branchName (#PR1, #PR2)
+# Format: currentDir on branchName* (#PR1, #PR2)
 #         Model: <model> | Context: <pct>% | 5h: <pct>% (<time>) | 7d: <pct>% (<time>)
 
 # Read JSON input from stdin (if available)
@@ -41,10 +41,14 @@ else
   current_dir=$(basename "$PWD")
 fi
 
-# Get Git branch
+# Get Git branch and diff stats
 git_branch=""
+git_diff=""
 if git rev-parse --git-dir >/dev/null 2>&1; then
   git_branch=$(git branch --show-current 2>/dev/null)
+  if [[ -n "$(git status --short 2>/dev/null)" ]]; then
+    git_diff="*"
+  fi
 fi
 
 # Get PR numbers with hyperlinks (if gh CLI is available)
@@ -146,7 +150,7 @@ output=""
 # Directory, branch, and PR (colors match starship.toml)
 output+="${YELLOW}${current_dir}${RESET}"
 if [[ -n "$git_branch" ]]; then
-  output+=" on ${GREEN}${git_branch}${RESET}"
+  output+=" on ${GREEN}${git_branch}${git_diff}${RESET}"
 fi
 if [[ -n "$pr_numbers" ]]; then
   output+=" (${pr_numbers})"


### PR DESCRIPTION
## Why

To make it easy to see at a glance whether the working tree has uncommitted changes, especially useful when AI coding agents are making rapid file modifications.

## What

- Add `*` indicator appended to branch name when there are uncommitted changes (staged, modified, or untracked files)
- Shows nothing when the working tree is clean

## Notes

Uses `git status --short` to detect dirty state. Format follows the common convention (e.g. oh-my-zsh, pure) of `branch-name*`.