### PR TITLE
feat(agents): set up gh skill automated install and update

### DIFF
--- a/bin/dots
+++ b/bin/dots
@@ -16,6 +16,11 @@ dots_up() {
   echo "\nUpdating gh extensions..."
   gh extension upgrade --all
 
+  echo "\nUpdating gh skills..."
+  while IFS= read -r skill; do
+    gh skill update "$skill" --dir "$HOME/.agents/skills"
+  done < <(jq -r '.skills | keys[]' "$HOME/.agents/.skill-lock.json")
+
   echo "\nUpdating Claude Code..."
   claude update
 

--- a/bin/dots
+++ b/bin/dots
@@ -16,10 +16,12 @@ dots_up() {
   echo "\nUpdating gh extensions..."
   gh extension upgrade --all
 
-  echo "\nUpdating gh skills..."
-  while IFS= read -r skill; do
-    gh skill update "$skill" --dir "$HOME/.agents/skills"
-  done < <(jq -r '.skills | keys[]' "$HOME/.agents/.skill-lock.json")
+  if [ -f "$HOME/.agents/.skill-lock.json" ]; then
+    echo "\nUpdating gh skills..."
+    while IFS= read -r skill; do
+      gh skill update "$skill" --dir "$HOME/.agents/skills"
+    done < <(jq -r '.skills | keys[]' "$HOME/.agents/.skill-lock.json")
+  fi
 
   echo "\nUpdating Claude Code..."
   claude update

--- a/home/.agents/skills/.gitignore
+++ b/home/.agents/skills/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!personal-*/
+!personal-*/**

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -153,13 +153,17 @@ else
 fi
 
 if type gh &>/dev/null; then
-  log_info "Installing gh skills..."
+  if [ -f "$DOTFILES_DIR/home/.agents/.skill-lock.json" ]; then
+    log_info "Installing gh skills..."
 
-  while IFS=' ' read -r skill repo; do
-    gh skill install "$repo" "$skill" --dir "$DOTFILES_DIR/home/.agents/skills" --force
-  done < <(jq -r '.skills | to_entries[] | "\(.key) \(.value.source)"' "$DOTFILES_DIR/home/.agents/.skill-lock.json")
+    while IFS=' ' read -r skill repo; do
+      gh skill install "$repo" "$skill" --dir "$DOTFILES_DIR/home/.agents/skills" --force
+    done < <(jq -r '.skills | to_entries[] | "\(.key) \(.value.source)"' "$DOTFILES_DIR/home/.agents/.skill-lock.json")
 
-  log_success "Successfully installed gh skills."
+    log_success "Successfully installed gh skills."
+  else
+    log_info "No .skill-lock.json found. Skipping gh skills installation."
+  fi
 else
   log_warn "gh command not found. Skipping gh skills installation."
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -152,6 +152,18 @@ else
   log_warn "gh command not found. Skipping gh extensions installation."
 fi
 
+if type gh &>/dev/null; then
+  log_info "Installing gh skills..."
+
+  while IFS=' ' read -r skill repo; do
+    gh skill install "$repo" "$skill" --dir "$DOTFILES_DIR/home/.agents/skills" --force
+  done < <(jq -r '.skills | to_entries[] | "\(.key) \(.value.source)"' "$DOTFILES_DIR/home/.agents/.skill-lock.json")
+
+  log_success "Successfully installed gh skills."
+else
+  log_warn "gh command not found. Skipping gh skills installation."
+fi
+
 if [ "$CI" != "true" ]; then
   if type deno &>/dev/null; then
     if type code &>/dev/null; then


### PR DESCRIPTION
## Why

Automate `gh skill` install and update as part of dotfiles management.

## What

- Add `gh skill install` to `install.sh` using `.skill-lock.json` as the source of truth
- Add `gh skill update` to `dots up` targeting only skills listed in `.skill-lock.json`
- Add `home/.agents/skills/.gitignore` to exclude externally installed skills from Git

## Notes

Replacing `personal-use-opensrc` with the official `opensrc` skill will be handled in a separate PR.