### PR TITLE
feat(claude): allow WebFetch to vitest.dev

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -36,6 +36,7 @@
       "WebFetch(domain:github.com)",
       "WebFetch(domain:qiita.com)",
       "WebFetch(domain:raw.githubusercontent.com)",
+      "WebFetch(domain:vitest.dev)",
       "WebFetch(domain:zenn.dev)",
       "WebSearch",
       "Skill",


### PR DESCRIPTION
## Why

`vitest.dev` was not in the allowed domains list, blocking WebFetch access when needed.

## What

Add `vitest.dev` to the WebFetch allowed domains in `settings.json`.

## Notes