### PR TITLE
refactor(codex): remove explicit Codex config

### DIFF
--- a/home/.codex/config.toml
+++ b/home/.codex/config.toml
@@ -1,5 +1,0 @@
-model = "gpt-5.1-codex-max"
-model_reasoning_effort = "medium"
-
-[features]
-web_search_request = true


### PR DESCRIPTION
## Why

The tracked Codex config only pinned an older model, kept the default reasoning effort, and enabled a deprecated web search flag.

## What

- remove `home/.codex/config.toml`
- let Codex follow its built-in defaults instead of carrying stale local settings

## Notes

- no unrelated files were included in this PR