### PR TITLE
feat(claude): allow `npm view` permission

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -29,6 +29,7 @@
       "Bash(gh review-comment list)",
       "Bash(gh review-comment list *)",
       "Bash(head *)",
+      "Bash(npm view *)",
       "Bash(opensrc *)",
       "Bash(rg -uuu *)",
       "Bash(tail *)",


### PR DESCRIPTION
## Why

Allow the `npm view` command to be used without a permission prompt.

## What

Add `Bash(npm view *)` to the allow list in `.claude/settings.json`.

## Notes
