### PR TITLE
feat(agents): add unpushed commit check to personal-merge-pr skill

### DIFF
--- a/home/.agents/skills/personal-merge-pr/SKILL.md
+++ b/home/.agents/skills/personal-merge-pr/SKILL.md
@@ -1,12 +1,23 @@
 ---
 name: personal-merge-pr
 description: ユーザーが PR のマージを求めたときや、エージェントが PR をマージするときに必ず使用してください。
-allowed-tools: Bash(gh review-comment list *), Bash(gh pr checks), Bash(gh repo view *)
+allowed-tools: Bash(gh review-comment list *), Bash(gh pr checks), Bash(gh repo view *), Bash(git fetch), Bash(git log *)
 ---
 
 # GitHub PR マージ
 
 ## ワークフロー
+
+### 未 push のコミットを確認する
+
+以下のコマンドで、ローカルにあってリモートにないコミットを確認します。
+
+```sh
+git fetch
+git log origin/$(git branch --show-current)..HEAD --oneline
+```
+
+未 push のコミットがある場合は、PR に反映されていない変更が存在する可能性があるため、ユーザーに確認します。
 
 ### レビューコメントを確認する
 


### PR DESCRIPTION
## Why

Verify there are no unpushed commits before merging to prevent changes that should be included in the PR from being missing.

## What

- Add "Check unpushed commits" step at the beginning of the `personal-merge-pr` skill workflow
- Detect unpushed commits with `git fetch` + `git log origin/<branch>..HEAD` and ask the user if any are found
- Add `Bash(git fetch)` and `Bash(git log *)` to `allowed-tools`

## Notes

- Checking for remote-only commits (need to pull) is intentionally excluded — `gh pr merge` runs on GitHub's side, so local state doesn't affect the merge
- Checking for uncommitted changes is also intentionally excluded — they are likely unrelated WIP left intentionally
