### PR TITLE
feat(agents): improve personal-create-branch skill description

### DIFF
--- a/home/.agents/skills/personal-create-branch/SKILL.md
+++ b/home/.agents/skills/personal-create-branch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: personal-create-branch
-description: Git リポジトリの慣習に則って新しいブランチを作成します。ユーザーがブランチの作成を求めたときや、エージェントが `git branch` や `git checkout -b`、`git switch -c` を用いてブランチを作成するときに必ず使用してください。
+description: Git リポジトリの慣習に則って新しいブランチを作成します。ユーザーがブランチの作成を求めたときや、エージェントが `git branch` や `git checkout -b`、`git switch -c` などを用いてブランチを作成するときに必ず使用してください。
 allowed-tools: Bash(git status), Bash(git status *), Bash(git diff), Bash(git diff *)
 ---
 

--- a/home/.agents/skills/personal-create-branch/SKILL.md
+++ b/home/.agents/skills/personal-create-branch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: personal-create-branch
-description: Git リポジトリの慣習に則って新しいブランチを作成します。ユーザーがブランチの作成を求めたときや、エージェントがブランチを作成するときに必ず使用してください。
+description: Git リポジトリの慣習に則って新しいブランチを作成します。ユーザーがブランチの作成を求めたときや、エージェントが `git branch` や `git checkout -b`、`git switch -c` を用いてブランチを作成するときに必ず使用してください。
 allowed-tools: Bash(git status), Bash(git status *), Bash(git diff), Bash(git diff *)
 ---
 


### PR DESCRIPTION
## Why

The `personal-create-branch` skill was firing inconsistently. Making the description more explicit about trigger conditions improves reliability.

## What

- Added specific git commands (`git branch`, `git checkout -b`, `git switch -c`) to the skill description

## Notes