### PR TITLE
feat(claude): allow `git fetch` permission

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -3,6 +3,8 @@
   "permissions": {
     "allow": [
       "Bash(fd -u *)",
+      "Bash(git fetch)",
+      "Bash(git fetch *)",
       "Bash(git log)",
       "Bash(git log *)",
       "Bash(gh release list)",


### PR DESCRIPTION
## Why

Allow `git fetch` to be executed from Claude Code.

## What

- Add `Bash(git fetch)` to the allowlist
- Add `Bash(git fetch *)` to the allowlist

## Notes