### PR TITLE
feat(claude): add hooks to block grep and find commands

### DIFF
--- a/home/.claude/hooks/block-find.sh
+++ b/home/.claude/hooks/block-find.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+jq -n '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: "Use fd -u instead of find"
+  }
+}'

--- a/home/.claude/hooks/block-grep.sh
+++ b/home/.claude/hooks/block-grep.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+jq -n '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: "Use rg -uuu instead of grep"
+  }
+}'

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -61,6 +61,23 @@
     ]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(grep *)",
+            "command": "~/.claude/hooks/block-grep.sh"
+          },
+          {
+            "type": "command",
+            "if": "Bash(find *)",
+            "command": "~/.claude/hooks/block-find.sh"
+          }
+        ]
+      }
+    ],
     "Notification": [
       {
         "matcher": "permission_prompt",


### PR DESCRIPTION
## Why

AGENTS.md defines that `rg -uuu` should be used instead of `grep` and `fd -u` instead of `find`, but agents occasionally use the wrong commands. These hooks enforce the convention by blocking them.

## What

- Add `PreToolUse` hooks with `block-grep.sh` and `block-find.sh`
- Use `if: "Bash(grep *)"` / `if: "Bash(find *)"` to filter target commands and return deny

## Notes

- Subcommands in pipes (e.g. `ls | grep ...`) are also blocked since each subcommand is matched independently