### PR TITLE
feat(claude): add hook to block git -C usage

### DIFF
--- a/home/.claude/hooks/block-find.sh
+++ b/home/.claude/hooks/block-find.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 
-jq -n '{
-  hookSpecificOutput: {
-    hookEventName: "PreToolUse",
-    permissionDecision: "deny",
-    permissionDecisionReason: "Use fd -u instead of find"
-  }
-}'
+# TODO: Replace with `if: "Bash(find *)"` once https://github.com/anthropics/claude-code/issues/48722 is fixed
+cmd=$(jq -r '.tool_input.command // ""')
+
+if echo "$cmd" | grep -qE '^find\b'; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "Use fd -u instead of find"
+    }
+  }'
+fi

--- a/home/.claude/hooks/block-git-c.sh
+++ b/home/.claude/hooks/block-git-c.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 
-jq -n '{
-  hookSpecificOutput: {
-    hookEventName: "PreToolUse",
-    permissionDecision: "deny",
-    permissionDecisionReason: "Do not use git -C. Run git commands from the working directory directly."
-  }
-}'
+# TODO: Replace with `if: "Bash(git -C *)"` once https://github.com/anthropics/claude-code/issues/48722 is fixed
+cmd=$(jq -r '.tool_input.command // ""')
+
+if echo "$cmd" | grep -qE '^git[[:space:]]+-C\b'; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "Do not use git -C. Run git commands from the working directory directly."
+    }
+  }'
+fi

--- a/home/.claude/hooks/block-git-c.sh
+++ b/home/.claude/hooks/block-git-c.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+jq -n '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: "Do not use git -C. Run git commands from the working directory directly."
+  }
+}'

--- a/home/.claude/hooks/block-grep.sh
+++ b/home/.claude/hooks/block-grep.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 
-jq -n '{
-  hookSpecificOutput: {
-    hookEventName: "PreToolUse",
-    permissionDecision: "deny",
-    permissionDecisionReason: "Use rg -uuu instead of grep"
-  }
-}'
+# TODO: Replace with `if: "Bash(grep *)"` once https://github.com/anthropics/claude-code/issues/48722 is fixed
+cmd=$(jq -r '.tool_input.command // ""')
+
+if echo "$cmd" | grep -qE '^grep\b'; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "Use rg -uuu instead of grep"
+    }
+  }'
+fi

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -66,17 +66,14 @@
         "hooks": [
           {
             "type": "command",
-            "if": "Bash(grep *)",
             "command": "~/.claude/hooks/block-grep.sh"
           },
           {
             "type": "command",
-            "if": "Bash(find *)",
             "command": "~/.claude/hooks/block-find.sh"
           },
           {
             "type": "command",
-            "if": "Bash(git -C *)",
             "command": "~/.claude/hooks/block-git-c.sh"
           }
         ]

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -51,7 +51,6 @@
       "mcp__figma-desktop__get_variable_defs"
     ],
     "deny": [
-      "Bash(git -C *)",
       "Bash(git add -A)",
       "Bash(sudo *)",
       "Read(.env*)",

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -74,6 +74,11 @@
             "type": "command",
             "if": "Bash(find *)",
             "command": "~/.claude/hooks/block-find.sh"
+          },
+          {
+            "type": "command",
+            "if": "Bash(git -C *)",
+            "command": "~/.claude/hooks/block-git-c.sh"
           }
         ]
       }


### PR DESCRIPTION
## Why

`git -C <path>` allows running git commands in a different directory, but Claude should always run git commands from the working directory directly.

## What

- Add `block-git-c.sh` hook that returns a descriptive deny message
- Register the hook in `settings.json` to fire when `git -C *` is used

## Notes

The `deny` rule for `Bash(git -C *)` already existed in `settings.json`, but without a helpful message. This hook provides the reason so Claude knows what to do instead.