### PR TITLE
feat(claude): allow `git ls-remote` permission

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -7,6 +7,8 @@
       "Bash(git fetch *)",
       "Bash(git log)",
       "Bash(git log *)",
+      "Bash(git ls-remote)",
+      "Bash(git ls-remote *)",
       "Bash(gh release list)",
       "Bash(gh release list *)",
       "Bash(gh release view)",


### PR DESCRIPTION
## Why

The `personal-create-pr` skill uses `git ls-remote --heads` to check if the current branch has been pushed to remote. Without this permission, Claude would prompt for approval on every PR creation.

## What

Add `Bash(git ls-remote)` and `Bash(git ls-remote *)` to the allow list in `home/.claude/settings.json`.

## Notes

None.