### PR TITLE
feat(claude): allow `git diff` permission

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -3,6 +3,8 @@
   "permissions": {
     "allow": [
       "Bash(fd -u *)",
+      "Bash(git diff)",
+      "Bash(git diff *)",
       "Bash(git fetch)",
       "Bash(git fetch *)",
       "Bash(git log)",


### PR DESCRIPTION
## Why

`git diff` is a read-only command frequently used to inspect changes, but it was not in the allow list.

## What

Add `Bash(git diff)` and `Bash(git diff *)` to the allow list in `home/.claude/settings.json`.

## Notes

None.