### PR TITLE
feat(claude): add PermissionRequest hook to log WebFetch URLs

### DIFF
--- a/home/.claude/hooks/log-web-fetch.sh
+++ b/home/.claude/hooks/log-web-fetch.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+INPUT=$(cat)
+
+URL=$(echo "$INPUT" | jq -r '.tool_input.url // ""')
+[ -z "$URL" ] && exit 0
+
+mkdir -p ~/.claude/logs
+echo "$(date -Iseconds) $URL" >> ~/.claude/logs/web-fetch.log

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -64,6 +64,17 @@
     ]
   },
   "hooks": {
+    "PermissionRequest": [
+      {
+        "matcher": "WebFetch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/log-web-fetch.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## Why

To understand which domains are triggering permission requests, in order to improve the WebFetch allowlist.

## What

- Add a `PermissionRequest` hook with `matcher: "WebFetch"`
- Add `log-web-fetch.sh` that records the requested WebFetch URL with a timestamp to `~/.claude/logs/web-fetch.log`

## Notes

After collecting logs, the plan is to identify domains worth adding to the allowlist.