### PR TITLE
fix(zsh): initialize starship before mise activate

### DIFF
--- a/home/.config/zsh/.zshrc
+++ b/home/.config/zsh/.zshrc
@@ -8,16 +8,16 @@ bindkey '^[[1;2D' backward-word
 # Forward word (Shift + Arrow Right)
 bindkey '^[[1;2C' forward-word
 
+if type starship &>/dev/null; then
+  eval "$(starship init zsh)"
+fi
+
 if type mise &>/dev/null; then
   eval "$(mise activate zsh)"
 fi
 
 if type sheldon &>/dev/null; then
   eval "$(sheldon source)"
-fi
-
-if type starship &>/dev/null; then
-  eval "$(starship init zsh)"
 fi
 
 if type fzf &>/dev/null; then


### PR DESCRIPTION
## Why

After `mise up` upgrades starship, the current shell session breaks with:

```
zsh: no such file or directory: /Users/p-chan/.local/share/mise/installs/github-starship-starship/1.25.0/starship
```

`starship init zsh` embeds the resolved binary path into `STARSHIP_BIN`. When `mise activate zsh` runs first, it prepends versioned binary dirs to PATH, so `STARSHIP_BIN` captures the versioned path (e.g. `.../1.25.0/starship`). After `mise up` removes the old version directory, that path is gone and the shell breaks.

## What

Moved `starship init zsh` before `mise activate zsh` in `.zshrc`.

Since `.zshenv` adds the shims directory to the front of PATH via `mise activate zsh --shims`, running `starship init zsh` before `mise activate zsh` ensures `STARSHIP_BIN` captures the shim path (`~/.local/share/mise/shims/starship`), which remains stable across version upgrades.

## Notes

N/A