### PR TITLE
feat(claude): add codex plugin from openai

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -124,7 +124,16 @@
     "command": "bash ~/.claude/statusline.sh"
   },
   "enabledPlugins": {
-    "example-skills@anthropic-agent-skills": true
+    "example-skills@anthropic-agent-skills": true,
+    "codex@openai-codex": true
+  },
+  "extraKnownMarketplaces": {
+    "openai-codex": {
+      "source": {
+        "source": "github",
+        "repo": "openai/codex-plugin-cc"
+      }
+    }
   },
   "language": "japanese",
   "feedbackSurveyRate": 0,


### PR DESCRIPTION
## Why

To install the Codex plugin from openai/codex-plugin-cc into Claude Code.

## What

- Add `codex@openai-codex` to `enabledPlugins`
- Add `openai-codex` marketplace (`openai/codex-plugin-cc`) to `extraKnownMarketplaces`

## Notes

None