### PR TITLE
fix(zsh): add mise shims to PATH unconditionally in .zshenv

### DIFF
--- a/home/.config/zsh/.zshenv
+++ b/home/.config/zsh/.zshenv
@@ -9,6 +9,7 @@ fi
 
 export DOTFILES_DIR="${CONFIGURED_DOTFILES_DIR:-$HOME/src/github.com/p-chan/dotfiles}"
 export PATH="$HOME/.local/bin:$PATH"
+export PATH="$HOME/.local/share/mise/shims:$PATH"
 export PATH="$DOTFILES_DIR/bin:$PATH"
 
 if type mise &>/dev/null; then


### PR DESCRIPTION
## Why

In VSCode's integrated terminal, starship was not initializing because `mise activate zsh --shims` in `.zshenv` only ran when `mise` was already on `PATH` — which wasn't guaranteed at `.zshenv` evaluation time. As a result, `type starship` silently failed in `.zshrc`, leaving the default zsh prompt instead of the starship prompt.

## What

Add `~/.local/share/mise/shims` to `PATH` directly in `.zshenv`, independent of `type mise`.

This preserves the ordering from #451 (starship init before `mise activate zsh` in `.zshrc`) so `STARSHIP_BIN` continues to point to the stable shim path rather than a versioned install directory.

## Notes

N/A
