### PR TITLE
feat: add Command Line Tools update to dots up

### DIFF
--- a/bin/dots
+++ b/bin/dots
@@ -3,7 +3,16 @@
 set -euo pipefail
 
 dots_up() {
-  echo "Updating Homebrew..."
+  echo "Updating Command Line Tools..."
+  local clt_label
+  clt_label=$(softwareupdate -l 2>&1 | grep "Label: Command Line Tools" | sed 's/.*Label: //' | head -1)
+  if [[ -n "${clt_label}" ]]; then
+    sudo softwareupdate -i "${clt_label}"
+  else
+    echo "Command Line Tools is up to date."
+  fi
+
+  echo "\nUpdating Homebrew..."
   brew update
   brew upgrade
 


### PR DESCRIPTION
## Why

To automatically update Command Line Tools (CLT) as part of `dots up`.

## What

- Detect CLT updates via `softwareupdate` and install if available
- Run before Homebrew since CLT is a prerequisite for it

## Notes

- Requires `sudo` to install CLT updates
- Displays "Command Line Tools is up to date." when no update is available
- Only targets CLT, not macOS system updates