### PR TITLE
fix(dots): prevent script exit when no CLT update is available

### DIFF
--- a/bin/dots
+++ b/bin/dots
@@ -5,7 +5,7 @@ set -euo pipefail
 dots_up() {
   echo "Updating Command Line Tools..."
   local clt_label
-  clt_label=$(softwareupdate -l 2>&1 | grep "Label: Command Line Tools" | sed 's/.*Label: //' | head -1)
+  clt_label=$(softwareupdate -l 2>&1 | grep "Label: Command Line Tools" | sed 's/.*Label: //' | head -1 || true)
   if [[ -n "${clt_label}" ]]; then
     sudo softwareupdate -i "${clt_label}"
   else


### PR DESCRIPTION
## Why

`dots up` was silently exiting after printing \"Updating Command Line Tools...\" with no further output. The root cause was that `grep` returns exit code 1 when there are no matching lines, and with `set -euo pipefail` enabled, this caused the entire pipeline to fail and the script to exit immediately.

## What

Added `|| true` to the `softwareupdate -l` pipeline so the script continues normally when no CLT update is available.

## Notes

N/A