### PR TITLE
refactor(git,zsh): replace git() wrapper with git alias for switch

### DIFF
--- a/bin/git-fallback-switch
+++ b/bin/git-fallback-switch
@@ -7,11 +7,11 @@
 
 set -euo pipefail
 
-_switch() { exec git -c "alias.switch=" switch "$@"; }
+raw_switch() { exec git -c "alias.switch=" switch "$@"; }
 
 # If the first arg is an option (e.g. --help, -c), respect it and delegate to git.
 if [[ "${1-}" == -* ]]; then
-  _switch "$@"
+  raw_switch "$@"
 fi
 
 target_branch="${1:-main}"
@@ -19,20 +19,20 @@ shift || true
 
 # For any branch other than main/master, just try to switch normally
 if [[ "$target_branch" != "main" && "$target_branch" != "master" ]]; then
-  _switch "$target_branch" "$@"
+  raw_switch "$target_branch" "$@"
 fi
 
 fallback_branch=$([ "$target_branch" = "main" ] && echo master || echo main)
 
 # prefer target if it exists
 if git rev-parse --verify --quiet "$target_branch" >/dev/null; then
-  _switch "$target_branch" "$@"
+  raw_switch "$target_branch" "$@"
 fi
 
 # fallback if it exists
 if git rev-parse --verify --quiet "$fallback_branch" >/dev/null; then
-  _switch "$fallback_branch" "$@"
+  raw_switch "$fallback_branch" "$@"
 fi
 
 # neither exists: let git show the usual error
-_switch "$target_branch" "$@"
+raw_switch "$target_branch" "$@"

--- a/bin/git-fallback-switch
+++ b/bin/git-fallback-switch
@@ -7,9 +7,11 @@
 
 set -euo pipefail
 
+_switch() { exec git -c "alias.switch=" switch "$@"; }
+
 # If the first arg is an option (e.g. --help, -c), respect it and delegate to git.
 if [[ "${1-}" == -* ]]; then
-  exec git -c "alias.switch=" switch "$@"
+  _switch "$@"
 fi
 
 target_branch="${1:-main}"
@@ -17,20 +19,20 @@ shift || true
 
 # For any branch other than main/master, just try to switch normally
 if [[ "$target_branch" != "main" && "$target_branch" != "master" ]]; then
-  exec git -c "alias.switch=" switch "$target_branch" "$@"
+  _switch "$target_branch" "$@"
 fi
 
 fallback_branch=$([ "$target_branch" = "main" ] && echo master || echo main)
 
 # prefer target if it exists
 if git rev-parse --verify --quiet "$target_branch" >/dev/null; then
-  exec git -c "alias.switch=" switch "$target_branch" "$@"
+  _switch "$target_branch" "$@"
 fi
 
 # fallback if it exists
 if git rev-parse --verify --quiet "$fallback_branch" >/dev/null; then
-  exec git -c "alias.switch=" switch "$fallback_branch" "$@"
+  _switch "$fallback_branch" "$@"
 fi
 
 # neither exists: let git show the usual error
-exec git -c "alias.switch=" switch "$target_branch" "$@"
+_switch "$target_branch" "$@"

--- a/bin/git-fallback-switch
+++ b/bin/git-fallback-switch
@@ -9,7 +9,7 @@ set -euo pipefail
 
 # If the first arg is an option (e.g. --help, -c), respect it and delegate to git.
 if [[ "${1-}" == -* ]]; then
-  exec git switch "$@"
+  exec git -c "alias.switch=" switch "$@"
 fi
 
 target_branch="${1:-main}"
@@ -17,20 +17,20 @@ shift || true
 
 # For any branch other than main/master, just try to switch normally
 if [[ "$target_branch" != "main" && "$target_branch" != "master" ]]; then
-  exec git switch "$target_branch" "$@"
+  exec git -c "alias.switch=" switch "$target_branch" "$@"
 fi
 
 fallback_branch=$([ "$target_branch" = "main" ] && echo master || echo main)
 
 # prefer target if it exists
 if git rev-parse --verify --quiet "$target_branch" >/dev/null; then
-  exec git switch "$target_branch" "$@"
+  exec git -c "alias.switch=" switch "$target_branch" "$@"
 fi
 
 # fallback if it exists
 if git rev-parse --verify --quiet "$fallback_branch" >/dev/null; then
-  exec git switch "$fallback_branch" "$@"
+  exec git -c "alias.switch=" switch "$fallback_branch" "$@"
 fi
 
 # neither exists: let git show the usual error
-exec git switch "$target_branch" "$@"
+exec git -c "alias.switch=" switch "$target_branch" "$@"

--- a/bin/git-fallback-switch
+++ b/bin/git-fallback-switch
@@ -7,11 +7,11 @@
 
 set -euo pipefail
 
-raw_switch() { exec git -c "alias.switch=" switch "$@"; }
+_raw_switch() { exec git -c "alias.switch=" switch "$@"; }
 
 # If the first arg is an option (e.g. --help, -c), respect it and delegate to git.
 if [[ "${1-}" == -* ]]; then
-  raw_switch "$@"
+  _raw_switch "$@"
 fi
 
 target_branch="${1:-main}"
@@ -19,20 +19,20 @@ shift || true
 
 # For any branch other than main/master, just try to switch normally
 if [[ "$target_branch" != "main" && "$target_branch" != "master" ]]; then
-  raw_switch "$target_branch" "$@"
+  _raw_switch "$target_branch" "$@"
 fi
 
 fallback_branch=$([ "$target_branch" = "main" ] && echo master || echo main)
 
 # prefer target if it exists
 if git rev-parse --verify --quiet "$target_branch" >/dev/null; then
-  raw_switch "$target_branch" "$@"
+  _raw_switch "$target_branch" "$@"
 fi
 
 # fallback if it exists
 if git rev-parse --verify --quiet "$fallback_branch" >/dev/null; then
-  raw_switch "$fallback_branch" "$@"
+  _raw_switch "$fallback_branch" "$@"
 fi
 
 # neither exists: let git show the usual error
-raw_switch "$target_branch" "$@"
+_raw_switch "$target_branch" "$@"

--- a/home/.config/git/config
+++ b/home/.config/git/config
@@ -14,6 +14,7 @@
   c = commit
   co = checkout
   sw = switch
+  switch = !git-fallback-switch
 
 [init]
   defaultBranch = main

--- a/home/.config/zsh/.zshrc
+++ b/home/.config/zsh/.zshrc
@@ -112,15 +112,3 @@ if [[ -f "${ZDOTDIR:-$HOME}/.zshrc.local" ]]; then
   source "${ZDOTDIR:-$HOME}/.zshrc.local"
 fi
 
-# Git wrapper
-git() {
-  case "${1-}" in
-    switch)
-      shift
-      command git-fallback-switch "$@"
-      ;;
-    *)
-      command git "$@"
-      ;;
-  esac
-}


### PR DESCRIPTION
## Why

Using a zsh `git()` wrapper function to redirect `git switch` to `git-fallback-switch` is fragile because any other tool that also wraps `git` would conflict with it. A git alias is the more appropriate mechanism for overriding git subcommands.

## What

- Add `git config alias.switch = !git-fallback-switch`
- Update internal `git switch` calls in `git-fallback-switch` to `git -c "alias.switch=" switch` to prevent infinite recursion
- Extract `_raw_switch` helper function to deduplicate the bypass calls
- Remove `git()` wrapper from `.zshrc`

## Notes

`alias.sw = switch` is preserved, so `git sw` also routes through `git-fallback-switch` via alias chaining.