### PR TITLE
feat(git): set wt.basedir to .git/wt

### DIFF
--- a/home/.config/git/config
+++ b/home/.config/git/config
@@ -38,5 +38,8 @@
 [ghq]
   root = ~/src
 
+[wt]
+  basedir = .git/wt
+
 [include]
   path = config.local


### PR DESCRIPTION
## Why

Placing worktrees inside `.git/wt` prevents tools like linters and Claude Code from scanning worktree directories or double-loading config files (e.g. `CLAUDE.md`). Most tools ignore `.git/` by default.

## What

- Add `[wt] basedir = .git/wt` to global git config

## Notes

This is a global default. Per-repository overrides are still possible via `git config --local wt.basedir`.