### PR TITLE
feat(mise): use gh auth token as GitHub credential

### DIFF
--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -38,3 +38,6 @@ macos-arm64 = { asset_pattern = "jq-macos-arm64" }
 [settings]
 experimental = true
 idiomatic_version_file_enable_tools = ['node']
+
+[settings.github]
+credential_command = "gh auth token"


### PR DESCRIPTION
## Why

mise uses GitHub API to resolve `latest` versions for `github:*` tools. Without authentication, requests are unauthenticated and subject to a 60 req/hour rate limit. Running `mise install` resolves all tools simultaneously, easily hitting the limit when many `github:*` tools are configured.

gh stores tokens in the macOS keychain, so mise cannot detect them automatically from `hosts.yml`.

## What

Add `credential_command = "gh auth token"` to `[settings.github]` in mise config so mise calls `gh auth token` to obtain an authenticated token (5000 req/hour).

## Notes

- Requires `gh` to be authenticated (`gh auth login`)
- No token is hardcoded; `gh` manages token storage
