### PR TITLE
refactor(claude): remove `language` setting

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -135,7 +135,6 @@
       }
     }
   },
-  "language": "japanese",
   "feedbackSurveyRate": 0,
   "alwaysThinkingEnabled": true,
   "autoMemoryEnabled": false,


### PR DESCRIPTION
## Why

Setting `"language": "japanese"` in `settings.json` causes Claude to prioritize that language setting in all contexts, overriding skill-level instructions. For example, even when a skill explicitly instructs Claude to write commit messages in English, the `settings.json` setting takes precedence and the skill instruction is ignored.

## What

- Remove `"language": "japanese"` from `home/.claude/settings.json`

## Notes

Language instructions are managed via `CLAUDE.md` (`ユーザーとは、日本語で会話します`).
