### PR TITLE
feat(git): add .playwright-cli to global gitignore

### DIFF
--- a/home/.config/git/ignore
+++ b/home/.config/git/ignore
@@ -6,3 +6,4 @@ Thumbs.db
 
 # Others
 opensrc/
+.playwright-cli/


### PR DESCRIPTION
## Why

Prevent `.playwright-cli/` directory generated by the playwright-cli skill from being accidentally committed to repositories.

## What

- Add `.playwright-cli/` to global gitignore (`home/.config/git/ignore`)

## Notes

None
