### PR TITLE
feat(agents): add diff check step to personal-create-pr

### DIFF
--- a/home/.agents/skills/personal-create-pr/SKILL.md
+++ b/home/.agents/skills/personal-create-pr/SKILL.md
@@ -73,9 +73,18 @@ git ls-remote --heads origin <branch-name>
 git push -u origin <branch-name>
 ```
 
-### 4. タイトルと本文の生成
+### 4. 差分確認
 
-最初に判定した言語とスタイル、その次に確認したテンプレートを遵守して、タイトルと本文を生成します。
+以下のコマンドでベースブランチとヘッドブランチの差分を確認します。
+
+```sh
+git log <base-branch>..HEAD --oneline
+git diff <base-branch>...HEAD --stat
+```
+
+### 5. タイトルと本文の生成
+
+言語とスタイル、テンプレート、差分をもとに、タイトルと本文を生成します。
 
 テンプレートが存在しない場合は、以下のテンプレートを利用してください。
 
@@ -87,7 +96,7 @@ git push -u origin <branch-name>
 ## Notes
 ```
 
-### 5. 作成
+### 6. 作成
 
 ```sh
 gh pr create \


### PR DESCRIPTION
## Why

To help the agent generate more accurate PR titles and bodies by inspecting the actual changes before writing.

## What

- Add step 4 "差分確認" that runs `git log` and `git diff` before generating the PR description
- Renumber subsequent steps (5 → 6)

## Notes
