### PR TITLE
chore(apm): update lock file to apm 0.19.0

### DIFF
--- a/home/.apm/apm.lock.yaml
+++ b/home/.apm/apm.lock.yaml
@@ -1,29 +1,58 @@
 lockfile_version: '1'
-generated_at: '2026-06-08T14:56:43.031844+00:00'
-apm_version: 0.18.0
+generated_at: '2026-06-10T13:31:51.340502+00:00'
+apm_version: 0.19.0
 dependencies:
 - repo_url: mattpocock/skills
   host: github.com
-  resolved_commit: 2bf70051928429983de3b5718d277150926f8c89
+  resolved_commit: 26ba8ae34bb3657e7dd85939fce8a5a166439f8b
   virtual_path: skills/productivity/grill-me
   is_virtual: true
   package_type: claude_skill
   deployed_files:
   - .agents/skills/grill-me
+  - .agents/skills/grill-me/SKILL.md
+  deployed_file_hashes:
+    .agents/skills/grill-me/SKILL.md: sha256:74147eb6010a65957efef2b9e0f0b3ff935c1def7fc117697151b1d0f3610556
   content_hash: sha256:784f0dbb7403b0f00324bce9a112f715342777a0daee7bbb7385f9c6f0a170ea
 - repo_url: microsoft/playwright-cli
   host: github.com
-  resolved_commit: 3a1bafc8b4e973c72d0364eb5b427d1ce0aa8317
+  resolved_commit: 9b118a1a737662fa118d591b5687340b86005d5c
   virtual_path: skills/playwright-cli
   is_virtual: true
   package_type: claude_skill
   deployed_files:
   - .agents/skills/playwright-cli
-  content_hash: sha256:a6045d16fe8fabaeb11574b103be0b2547358ccbbe8820a7ce00004d69bbc45f
+  - .agents/skills/playwright-cli/SKILL.md
+  - .agents/skills/playwright-cli/references/element-attributes.md
+  - .agents/skills/playwright-cli/references/playwright-tests.md
+  - .agents/skills/playwright-cli/references/request-mocking.md
+  - .agents/skills/playwright-cli/references/running-code.md
+  - .agents/skills/playwright-cli/references/session-management.md
+  - .agents/skills/playwright-cli/references/spec-driven-testing.md
+  - .agents/skills/playwright-cli/references/storage-state.md
+  - .agents/skills/playwright-cli/references/test-generation.md
+  - .agents/skills/playwright-cli/references/tracing.md
+  - .agents/skills/playwright-cli/references/video-recording.md
+  deployed_file_hashes:
+    .agents/skills/playwright-cli/SKILL.md: sha256:b4c81c39e39f30e4790607e57b12283878f3751daca9c0e44f301899f2108b13
+    .agents/skills/playwright-cli/references/element-attributes.md: sha256:bf19aa4671e0a50a0fefa9c790f39124e803060eefe395042b723c29fcb7faa2
+    .agents/skills/playwright-cli/references/playwright-tests.md: sha256:c5b0719fef2cfdff50bd744051b2f9afc119775db4b48e9b2882c1cf3886797c
+    .agents/skills/playwright-cli/references/request-mocking.md: sha256:54e801c9663fc2b6d68ceb058cb1c360724c2499f42acc7852a68e83e5b5f37c
+    .agents/skills/playwright-cli/references/running-code.md: sha256:d95c539a5990b71d02d8bdf1d9414df16191eb6cff95b0063820518b7a13dcb2
+    .agents/skills/playwright-cli/references/session-management.md: sha256:cd3e261b8763bf952f1e371b876cb78d054379afec85482f9250633e1b7e6c44
+    .agents/skills/playwright-cli/references/spec-driven-testing.md: sha256:3326b3af65ed6e05180aa394a7fd578f29822e67bde9f22f7c7f94e6c8e3a594
+    .agents/skills/playwright-cli/references/storage-state.md: sha256:9ac47f9ae4a1aedcd2077f8ac9ab1ba6bee1962cb83ff51adcd36fb6d83b5ec6
+    .agents/skills/playwright-cli/references/test-generation.md: sha256:2a9c4d94effa31b05cf367dfa8bbace8874a3bc9799987ad2b03269af224d299
+    .agents/skills/playwright-cli/references/tracing.md: sha256:792e0ac7705e56ac48df84c0f5400221ce86107897c671590a64a4ea6a82508e
+    .agents/skills/playwright-cli/references/video-recording.md: sha256:8555ab5400df0d90e66318aacc0a8a4418fbf872e7463824d55d5c41615abd83
+  content_hash: sha256:c75e106cec48dd02c8e87504a88e90d2b84f4472bfadf395e6fd4a86763c4a64
 - repo_url: vercel-labs/opensrc
   host: github.com
   resolved_commit: 2efd74e8f1755f15ed8f5a3445e1f5c80b6362c4
   package_type: skill_bundle
   deployed_files:
   - .agents/skills/opensrc
+  - .agents/skills/opensrc/SKILL.md
+  deployed_file_hashes:
+    .agents/skills/opensrc/SKILL.md: sha256:2c4d873a423e30dbdbabc30b104bef8f09eae00d9a186a952dfc88c53e2e34fb
   content_hash: sha256:b44b3394cc2ab58c4d34dbe479e70f9335ce8aad6ab221986d67da9a57b9672e


### PR DESCRIPTION
## Why

Keep apm and skill dependencies up to date.

## What

- Bump `apm_version` from 0.18.0 to 0.19.0
- Update `mattpocock/skills` (grill-me) to latest commit
- Update `microsoft/playwright-cli` to latest commit, adding reference docs
- Update `vercel-labs/opensrc` to include `SKILL.md`

## Notes

Lock file only — no functional changes.