### PR TITLE
fix(git,zsh): restore git-fallback-switch via zsh shell function

### DIFF
--- a/home/.config/git/config
+++ b/home/.config/git/config
@@ -14,7 +14,6 @@
   c = commit
   co = checkout
   sw = switch
-  switch = !git-fallback-switch
 
 [init]
   defaultBranch = main

--- a/home/.config/zsh/.zshrc
+++ b/home/.config/zsh/.zshrc
@@ -32,6 +32,25 @@ if type git-wt &>/dev/null; then
   eval "$(git wt --init zsh)"
 fi
 
+# git switch/sw → git-fallback-switch; composes with git-wt wrapper if present
+if typeset -f git > /dev/null 2>&1; then
+  functions[_git_before_switch]=${functions[git]}
+  unfunction git
+  git() {
+    case "${1-}" in
+      switch|sw) shift; command git-fallback-switch "$@" ;;
+      *) _git_before_switch "$@" ;;
+    esac
+  }
+else
+  git() {
+    case "${1-}" in
+      switch|sw) shift; command git-fallback-switch "$@" ;;
+      *) command git "$@" ;;
+    esac
+  }
+fi
+
 export FZF_DEFAULT_OPTS="
   --layout=reverse
   --color=fg:#abb2bf,fg+:#ffffff,bg:#282c34,bg+:#3e4452


### PR DESCRIPTION
## Why

The git alias `switch = !git-fallback-switch` in `git config` doesn't compose with the `git-wt` shell function wrapper — when `git` is already a shell function, git aliases are bypassed or conflict with the wrapper's dispatch logic.

## What

- Remove `switch = !git-fallback-switch` from `home/.config/git/config`
- Add a zsh shell function in `.zshrc` that wraps `git` to intercept `switch` and `sw` subcommands and delegate to `git-fallback-switch`, composing correctly with the existing `git-wt` wrapper when present

## Notes

The zsh function checks whether `git` is already a shell function (via `typeset -f git`). If so, it saves the existing function as `_git_before_switch` and wraps it; otherwise it wraps the bare `command git`.
