### PR TITLE
fix(agents): use full diff instead of --stat in personal-create-pr skill

### DIFF
--- a/home/.agents/skills/personal-create-pr/SKILL.md
+++ b/home/.agents/skills/personal-create-pr/SKILL.md
@@ -79,7 +79,7 @@ git push -u origin <branch-name>
 
 ```sh
 git log <base-branch>..HEAD --oneline
-git diff <base-branch>...HEAD --stat
+git diff <base-branch>...HEAD
 ```
 
 ### 5. タイトルと本文の生成


### PR DESCRIPTION
## Why

Using `--stat` only shows file names and line counts, which was insufficient for writing an accurate PR title and body. This was identified as the root cause of a PR description mismatch where the description was written from memory rather than from the actual diff.

## What

Replace `git diff <base-branch>...HEAD --stat` with `git diff <base-branch>...HEAD` in the diff confirmation step.

## Notes

-
