### PR TITLE
feat(claude): set defaultMode to auto and enable skipAutoPermissionPrompt

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -64,7 +64,8 @@
       "Read(!.env*.example)",
       "Write(.env*)",
       "Write(!.env*.example)"
-    ]
+    ],
+    "defaultMode": "auto"
   },
   "hooks": {
     "PermissionRequest": [
@@ -138,5 +139,6 @@
   "feedbackSurveyRate": 0,
   "alwaysThinkingEnabled": true,
   "autoMemoryEnabled": false,
-  "voiceEnabled": true
+  "voiceEnabled": true,
+  "skipAutoPermissionPrompt": true
 }


### PR DESCRIPTION
## Why

Enable auto mode and skip redundant permission prompts to reduce friction during agentic workflows.

## What

- Add `"defaultMode": "auto"` to permissions config
- Add `"skipAutoPermissionPrompt": true`

## Notes

-
