### PR TITLE
feat(claude): set dark theme

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -139,6 +139,7 @@
   "feedbackSurveyRate": 0,
   "alwaysThinkingEnabled": true,
   "autoMemoryEnabled": false,
+  "theme": "dark",
   "voiceEnabled": true,
   "skipAutoPermissionPrompt": true
 }


### PR DESCRIPTION
## Why

ダークテーマを使用したいため。

## What

- `home/.claude/settings.json` に `"theme": "dark"` を追加

## Notes

N/A
