### PR TITLE
feat(agents): add closing keyword instruction to personal-create-pr

### DIFF
--- a/home/.agents/skills/personal-create-pr/SKILL.md
+++ b/home/.agents/skills/personal-create-pr/SKILL.md
@@ -102,6 +102,14 @@ git diff <base-branch>...HEAD
 ## Notes
 ```
 
+この PR のマージによってクローズできる Issue がある場合は、本文に GitHub のクローズキーワードを含めます。
+
+```md
+Closes #123
+```
+
+クローズキーワード: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`
+
 ### 6. 作成
 
 ```sh


### PR DESCRIPTION
## Why

When a PR can close an Issue on merge, the agent needs explicit instructions to include a closing keyword in the PR body.

## What

Added instructions and a list of GitHub closing keywords to step 5 of `personal-create-pr` SKILL.md.

## Notes

None
