### PR TITLE
feat(dots): add Docker cleanup to dots cleanup

### DIFF
--- a/bin/dots
+++ b/bin/dots
@@ -76,6 +76,9 @@ dots_cleanup() {
   echo "\nCleaning pnpm..."
   command -v pnpm &>/dev/null && pnpm store prune || true
 
+  echo "\nCleaning Docker..."
+  command -v docker &>/dev/null && docker system prune -f || true
+
   local after
   after=($(_storage_snapshot))
   local freed=$(awk "BEGIN {printf \"%.2f\", ${before[1]} - ${after[1]}}")


### PR DESCRIPTION
## Why

Reclaim disk space occupied by Docker's stopped containers, unused networks, dangling images, and build cache as part of the `dots cleanup` routine.

## What

- Add `docker system prune -f` to `dots_cleanup` in `bin/dots`
- Guarded with `command -v docker` so it's safely skipped when Docker is not installed

## Notes

Uses `-f` (not `-af`) to preserve tagged images, avoiding slow re-pulls on the next `docker compose up`.