### PR TITLE
feat(dots): add opensrc cleanup to dots cleanup

### DIFF
--- a/bin/dots
+++ b/bin/dots
@@ -79,6 +79,9 @@ dots_cleanup() {
   echo "\nCleaning Docker..."
   command -v docker &>/dev/null && docker system prune -f || true
 
+  echo "\nCleaning opensrc..."
+  command -v opensrc &>/dev/null && opensrc clean || true
+
   local after
   after=($(_storage_snapshot))
   local freed=$(awk "BEGIN {printf \"%.2f\", ${before[1]} - ${after[1]}}")


### PR DESCRIPTION
## Why

Clean up cached dependency source code fetched by opensrc as part of the `dots cleanup` routine.

## What

- Add `opensrc clean` to `dots_cleanup` in `bin/dots`
- Guarded with `command -v opensrc` so it's safely skipped when opensrc is not installed

## Notes

`opensrc clean` does not prompt for confirmation, so no additional flags are needed.