### PR TITLE
feat(starship): add git dirty indicator with custom module

### DIFF
--- a/home/.config/starship.toml
+++ b/home/.config/starship.toml
@@ -1,6 +1,6 @@
 "$schema" = "https://starship.rs/config-schema.json"
 
-format = "$character$directory$git_branch"
+format = "$character$directory${custom.git_branch}"
 right_format = "$time"
 add_newline = false
 
@@ -12,8 +12,10 @@ truncation_length = 1
 format = "[$path](yellow) "
 fish_style_pwd_dir_length = 1
 
-[git_branch]
-format = "on [$branch](green) "
+[custom.git_branch]
+command = 'branch=$(git branch --show-current 2>/dev/null); dirty=$(git status --short 2>/dev/null | grep -q . && echo "*" || echo ""); echo "${branch}${dirty}"'
+when = 'git rev-parse --git-dir > /dev/null 2>&1'
+format = "on [$output](green) "
 
 [time]
 format = "[$time](#999999)"


### PR DESCRIPTION
## Why

The `git_branch` module manages the branch name and trailing space separately, causing a gap when inserting a dirty indicator (`*`), resulting in `main *` instead of `main*`.

## What

- Replace `[git_branch]` module with `[custom.git_branch]`
- Combine branch name and dirty state into a single module to display `main*` without extra spacing

## Notes

None