### PR TITLE
fix(zsh): apply fzf theme to fzf-tab

### DIFF
--- a/home/.config/zsh/.zshrc
+++ b/home/.config/zsh/.zshrc
@@ -60,6 +60,7 @@ _fzf_colors=(
 
 export FZF_DEFAULT_OPTS="--layout=reverse ${_fzf_colors[*]}"
 
+# fzf-tab ignores FZF_DEFAULT_OPTS by default; pass colors explicitly
 zstyle ':fzf-tab:*' fzf-flags $_fzf_colors
 
 HISTSIZE=100000

--- a/home/.config/zsh/.zshrc
+++ b/home/.config/zsh/.zshrc
@@ -51,13 +51,16 @@ else
   }
 fi
 
-export FZF_DEFAULT_OPTS="
-  --layout=reverse
+_fzf_colors=(
   --color=fg:#abb2bf,fg+:#ffffff,bg:#282c34,bg+:#3e4452
   --color=hl:#61afef,hl+:#61afef,info:#abb2bf,marker:#61afef
   --color=prompt:#61afef,spinner:#61afef,pointer:#528bff,header:#abb2bf
   --color=border:#5c6370,label:#abb2bf,query:#ffffff
-"
+)
+
+export FZF_DEFAULT_OPTS="--layout=reverse ${_fzf_colors[*]}"
+
+zstyle ':fzf-tab:*' fzf-flags $_fzf_colors
 
 HISTSIZE=100000
 SAVEHIST=100000


### PR DESCRIPTION
## Why

`fzf-tab` ignores `FZF_DEFAULT_OPTS` by default to avoid conflicts with its internally required options (e.g. `--delimiter`, `--nth`, `--print-query`). As a result, the fzf color theme was not applied when using tab completion.

## What

- Extract fzf color flags into a `_fzf_colors` array
- Pass it to both `FZF_DEFAULT_OPTS` and `fzf-tab`'s `fzf-flags` via `zstyle`
- Add a comment explaining why the explicit `zstyle` is needed

## Notes

This avoids duplicating color definitions while keeping fzf-tab's required options isolated from user-defined opts.