### PR TITLE
feat(agents): add personal-setup-node skill

### DIFF
--- a/home/.agents/skills/personal-setup-node/SKILL.md
+++ b/home/.agents/skills/personal-setup-node/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: personal-setup-node
+description: プロジェクトの Node.js バージョンをセットアップします。既存のバージョン指定の検出、LTS バージョンの選定と .node-version の生成、CI の Node.js セットアップへの反映を行います。.node-version を作成・更新するときや Node.js のバージョン指定を求められたときに使用してください。
+---
+
+# Node.js バージョンのセットアップ
+
+## ワークフロー
+
+1. 現状の検出
+2. バージョンの決定
+3. `.node-version` の生成
+4. CI への反映
+
+## 1. 現状の検出
+
+以下を確認する。
+
+- `.node-version` が存在するか（存在する場合は新規作成ではなく更新として扱う）
+- `.nvmrc` が存在するか。mise は `.nvmrc` を `.node-version` より優先して読むため、両方が存在すると `.node-version` の指定が無視される。`.nvmrc` は削除して `.node-version` に一本化する
+- `package.json` の `engines.node` が存在するか。存在する場合は、決定するバージョンがその範囲を満たすようにする
+- `.github/workflows/` に CI ワークフローが存在するか
+
+## 2. バージョンの決定
+
+原則として Active LTS を使う。
+
+Current（非 LTS）でしか使えない機能に依存しているなど、明確な理由がある場合に限り、特定のメジャーバージョンや `node@latest` を指定する。
+その場合は、LTS を使わない理由をユーザーに伝える。
+
+## 3. `.node-version` の生成
+
+```bash
+mise latest node@lts > .node-version
+```
+
+- `node@lts` は、その時点の Active LTS の最新パッチバージョンに解決される
+- メジャーバージョンを固定する場合は `mise latest node@24 > .node-version` のように指定する
+- `node@latest` は Current に解決されることがあるため、LTS を使う場合は `node@lts` を明示する
+- `mise latest` は解決できないバージョンを指定しても、終了コード 0 のまま空文字列を返す。そのままリダイレクトすると `.node-version` が空になるため、生成後に中身が `x.y.z` 形式であることを必ず確認する
+- 未インストールのバージョンでも、`node` 等を実行した時点で mise が自動インストールするため、別途 `mise install` を叩く必要はない
+
+## 4. CI への反映
+
+[references/ci.md](references/ci.md) に従う。

--- a/home/.agents/skills/personal-setup-node/references/ci.md
+++ b/home/.agents/skills/personal-setup-node/references/ci.md
@@ -1,0 +1,25 @@
+# CI への Node.js バージョンの反映
+
+`.github/workflows/` に CI ワークフローが存在する場合のみ更新する。存在しない場合は何もしない。
+
+## 反映手順
+
+`actions/setup-node` を使っているステップで、バージョンを `node-version-file` から読むように統一する。
+
+```yaml
+- uses: actions/setup-node@<SHA> # <最新タグ>
+  with:
+    node-version-file: .node-version
+```
+
+`actions/setup-node` のバージョンは、[personal-github-actions-best-practices スキル](../../personal-github-actions-best-practices/SKILL.md)に従い、最新版を SHA で固定する。
+
+## 既存の指定を置き換える場合
+
+- `node-version` にバージョンが直書きされている場合は、その行を削除して `node-version-file` に置き換える。`node-version` と `node-version-file` の両方が指定されている場合、`actions/setup-node` は `node-version` を優先するため、直書きを残したままでは `.node-version` が反映されない
+- `node-version-file` が `.nvmrc` を指している場合は `.node-version` に変更する（`.nvmrc` 自体はスキル本体のステップ1で削除する）
+- マトリックスビルドで複数の Node.js バージョンを意図的に試している場合は、`.node-version` に寄せずにマトリックスの指定を維持する
+
+## パッケージマネージャーのセットアップ
+
+`pnpm/action-setup` やキャッシュ設定など、パッケージマネージャー側のセットアップは、[personal-setup-pnpm スキルの CI 手順](../../personal-setup-pnpm/references/ci.md)に従う。


### PR DESCRIPTION
## Why

Pinning a project's Node.js version is a recurring, mechanical task, but two of
its details fail silently when they go wrong:

- Resolving `node@latest` can yield a non-LTS Current release. That contradicts
  the LTS policy `personal-setup-pnpm/references/ci.md` already assumes when it
  says to pin the LTS version in CI.
- A leftover `.nvmrc` outranks `.node-version` in mise, so generating
  `.node-version` looks like it succeeded while the old version keeps being used.

Skills should also stay portable, so this one sticks to mise's standard
subcommands rather than the custom `fnv` task defined in this repository.

## What

Add the `personal-setup-node` skill with a four-step workflow: detect the current
state, decide the version, generate `.node-version`, then reflect it in CI.

- Active LTS is the default, so `mise latest node@lts > .node-version` is the
  main path and deviating from LTS requires stating the reason.
- Detection covers an existing `.node-version`, a conflicting `.nvmrc`,
  `engines.node`, and whether CI exists at all.
- `references/ci.md` keeps `actions/setup-node` reading `node-version-file`, and
  defers to the pnpm skill for package-manager setup rather than duplicating it.

## Notes

Verified against the local mise (2026.7.12) instead of assuming:

- `mise latest node@lts` → `24.18.1` (Active LTS), `mise latest node@latest` →
  `26.5.1` (Current). The LTS-vs-`latest` gap is real as of today, not
  hypothetical.
- With `.node-version` = 24.18.1 and `.nvmrc` = 22.0.0 both present,
  `mise current node` reports `22.0.0` — `.nvmrc` wins.
- `mise latest node@999` exits `0` and prints nothing, so a bare redirect would
  leave `.node-version` empty. The custom `fnv` task guarded against this with a
  regex check; since the skill no longer uses it, the skill instead requires
  verifying the generated value looks like `x.y.z`.
- `not_found_auto_install` is `true`, so the pinned version installs on first
  use and no explicit `mise install` step is needed.
- `actions/setup-node`'s documented inputs confirm `node-version` takes
  precedence when both it and `node-version-file` are set, which is why the
  instruction is to delete the hardcoded value rather than leave it.
- `prettier --check` passes.

Rebased onto current `main`: this branch was 47 commits behind, and its original
two commits — which still recommended a redundant `mise install` — are squashed
into one.
