### PR TITLE
feat(agents): add personal-setup-oxc skill

### DIFF
--- a/home/.agents/skills/personal-setup-oxc/SKILL.md
+++ b/home/.agents/skills/personal-setup-oxc/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: personal-setup-oxc
+description: プロジェクトに oxlint と oxfmt をセットアップします。既存の ESLint/Prettier/Biome からの移行、設定ファイルの作成、package.json への lint/format スクリプト追加、type-aware lint の有効化判断、エディタ拡張の設定、CI へのジョブ追加を行います。oxlint や oxfmt のセットアップを求められたときに使用してください。
+---
+
+# oxlint / oxfmt セットアップ
+
+## 対象
+
+既存のリンターとフォーマッターの設定は、create-xxx 系のスキャフォールドが生成する程度のものを主な対象とする。
+個別の判断が必要な分岐（移行できないルールやプラグインの扱いなど）は [references/migration.md](references/migration.md) の各分岐でその都度ユーザーに確認する。
+
+## ワークフロー
+
+1. 現状の検出
+2. `oxlint` のインストール
+3. `oxfmt` のインストール
+4. 既存のリンターとフォーマッターからの移行（該当する場合）
+5. 設定ファイルの作成（必要な場合のみ）
+6. package.json への lint/format スクリプト追加
+7. type-aware lint の有効化判断
+8. エディタ拡張の設定（該当する場合）
+9. CI への追加
+
+## 1. 現状の検出
+
+以下を確認する。
+
+- パッケージマネージャー（`packageManager` フィールドやロックファイル）とモノレポ構成か（`workspaces` フィールドや `pnpm-workspace.yaml` など）
+- 既存のリンター（ESLint）、フォーマッター（Prettier）、統合ツール（Biome）の有無とその設定ファイル。モノレポの場合はルートだけでなく各パッケージも確認する
+- `oxlint` と `oxfmt` が既にインストールされているか（一方だけ導入済みなど部分的な場合も含む）
+- `.vscode/` ディレクトリの有無（手順8で使う）
+- CI ワークフロー（`.github/workflows/`）の有無（手順9で使う）
+
+## 2. oxlint のインストール
+
+既にインストール済みの場合は最新バージョンに更新する。未導入の場合は `oxlint` の最新バージョンを devDependencies としてインストールする。
+モノレポの場合はルートに1回だけインストールし、全パッケージで共有する。
+
+## 3. oxfmt のインストール
+
+既にインストール済みの場合は最新バージョンに更新する。未導入の場合は `oxfmt` の最新バージョンを devDependencies としてインストールする。
+モノレポの場合はルートに1回だけインストールし、全パッケージで共有する。
+
+## 4. 既存のリンターとフォーマッターからの移行（該当する場合）
+
+[references/migration.md](references/migration.md) に従う。
+既存のリンターとフォーマッターのどちらもない場合はこのステップをスキップする。
+
+## 5. 設定ファイルの作成（必要な場合のみ）
+
+基本的には設定を追加しない。oxlint と oxfmt はいずれもデフォルト設定のまま動作するよう設計されている。
+移行元の設定を引き継ぐ必要がある場合、または個別の除外設定が必要な場合のみ、[references/config.md](references/config.md) に従って作成する。
+
+## 6. package.json への lint/format スクリプト追加
+
+`scripts` に以下を追加する。ESLint、Prettier、Biome を実行する同等のスクリプトが既にある場合は置き換える。
+
+```json
+{
+  "scripts": {
+    "lint": "oxlint",
+    "lint:fix": "oxlint --fix",
+    "format": "oxfmt",
+    "format:check": "oxfmt --check"
+  }
+}
+```
+
+モノレポの場合もルートの `package.json` にのみ追加する。oxlint と oxfmt はいずれもディレクトリ単位で最も近い設定ファイルを適用しながらモノレポ全体を1コマンドで処理できるため、パッケージごとに設定や方針（手順4と7）が異なっていても集約スクリプトは1つでよい。ただし手順4で ESLint を並行運用するパッケージがある場合は、[references/migration.md](references/migration.md) に従ってそのパッケージ用の実行手段を別途追加する。
+
+## 7. type-aware lint の有効化判断
+
+プロジェクトが TypeScript を使用している場合、[references/type-aware.md](references/type-aware.md) に従って有効化を検討する。
+モノレポでは `tsconfig.json` がルートになく各パッケージ配下にのみ存在することがあるため、ルートだけでなく各パッケージも確認する。`tsconfig.json` がどこにも存在しない場合はこのステップをスキップする。
+
+## 8. エディタ拡張の設定（該当する場合）
+
+`.vscode/` ディレクトリが既に存在する場合のみ、[references/editor.md](references/editor.md) に従って設定する。
+存在しない場合は何もしない（新規に作成しない）。
+
+## 9. CI への追加
+
+[references/ci.md](references/ci.md) に従う。

--- a/home/.agents/skills/personal-setup-oxc/references/ci.md
+++ b/home/.agents/skills/personal-setup-oxc/references/ci.md
@@ -1,0 +1,51 @@
+# CI への lint/format-check ジョブ追加
+
+## 既存の CI ワークフローがある場合
+
+既存のワークフローに、手順6で追加した `lint` と `format:check` を実行するジョブを、それぞれ別ジョブとして追加する（どちらが落ちたか PR のステータスチェック一覧から一目で分かるようにするため）。
+Node.js のセットアップ方法、パッケージマネージャー、キャッシュ設定など、既存の他ジョブのスタイルに合わせる。
+ESLint、Prettier、Biome を実行していたジョブやステップがあれば置き換える。
+
+## 既存の CI ワークフローがない場合
+
+`.github/workflows/` に、`lint` と `format:check` を実行する最小限のワークフローを新規作成する。
+[personal-github-actions-best-practices スキル](../../personal-github-actions-best-practices/SKILL.md)に従い、`actions/checkout` などのバージョンを SHA で固定する。
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [<デフォルトブランチ>]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<SHA> # <最新タグ>
+      - uses: actions/setup-node@<SHA> # <最新タグ>
+        with:
+          node-version-file: .node-version # 実際のファイルに合わせる
+      - run: <検出したパッケージマネージャーのインストールコマンド>
+      - run: <lint スクリプトの実行コマンド>
+
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<SHA> # <最新タグ>
+      - uses: actions/setup-node@<SHA> # <最新タグ>
+        with:
+          node-version-file: .node-version # 実際のファイルに合わせる
+      - run: <検出したパッケージマネージャーのインストールコマンド>
+      - run: <format:check スクリプトの実行コマンド>
+```
+
+pnpm を使う場合の `pnpm/action-setup` の要否など、パッケージマネージャー固有のセットアップは手順1で検出した内容に合わせる（詳細は [personal-setup-pnpm スキル](../../personal-setup-pnpm/references/ci.md)を参照）。
+
+## 共通
+
+oxlint は GitHub Actions 環境を自動検出し、追加設定なしで PR 上に warning/error のアノテーションを表示する。
+
+モノレポの場合も、ルートで `lint` / `format:check` を実行するだけで全パッケージが対象になる。
+[migration.md](migration.md) の判断で ESLint を並行運用するパッケージがある場合は、そのパッケージの `lint:eslint` 相当のスクリプトを呼び出すステップも追加する。

--- a/home/.agents/skills/personal-setup-oxc/references/config.md
+++ b/home/.agents/skills/personal-setup-oxc/references/config.md
@@ -1,0 +1,26 @@
+# 設定ファイル
+
+## 配置場所とファイル名
+
+- oxlint: `.oxlintrc.json`（または `oxlint.config.ts`）。リント対象ファイルのディレクトリから上位に向かって探索し、最も近い設定ファイルが優先される。
+- oxfmt: `.oxfmtrc.json` / `.oxfmtrc.jsonc`（または `oxfmt.config.ts`）。探索方法は oxlint と同様。
+
+いずれも同一ディレクトリに JSON 系と TS 系の設定を共存させることはできない。モノレポでは、この探索の仕組みにより、ルートの設定に加えてパッケージ単位で上書きできる。プロジェクトの他の設定ファイルの形式に合わせ、特に理由がなければ `.json`（`.jsonc`）形式を使う。
+
+## 除外設定
+
+両ツールとも `.gitignore` を自動的に尊重するため、Git 管理外のファイルを個別に除外設定する必要はない。
+Git 管理下だが対象から除外したいファイル（自動生成されたが差分を追うためコミットしているファイルなど）がある場合のみ、各設定ファイルの `ignorePatterns`（`.gitignore` 構文）に追記する。レガシーな `.oxlintignore` / `.prettierignore` 形式は新規には作らない。
+
+## oxlint の主な設定項目
+
+- `rules`: ルール個別の有効化と無効化、重大度
+- `categories`: `correctness`、`suspicious`、`pedantic` などのカテゴリ単位の一括制御
+- `plugins`: 有効化するネイティブプラグイン一覧。指定するとデフォルトセットを上書きするため、デフォルトのプラグインに追加したいだけの場合はデフォルトのプラグインも含めて明記する
+- `overrides`: ファイルパターン別の設定上書き
+- `env` / `globals`: 環境変数とグローバル変数の宣言
+
+## oxfmt の主な設定項目
+
+Prettier とほぼ互換（`printWidth`、`semi`、`singleQuote`、`trailingComma` など）。
+oxfmt 独自の項目として `sortImports`（import 順序の自動整列）と `sortTailwindcss`（Tailwind CSS クラスの並び替え）があるが、移行元の Prettier 設定にはない項目のため、有効化するかどうかはユーザーに確認する。

--- a/home/.agents/skills/personal-setup-oxc/references/config.md
+++ b/home/.agents/skills/personal-setup-oxc/references/config.md
@@ -12,15 +12,11 @@
 両ツールとも `.gitignore` を自動的に尊重するため、Git 管理外のファイルを個別に除外設定する必要はない。
 Git 管理下だが対象から除外したいファイル（自動生成されたが差分を追うためコミットしているファイルなど）がある場合のみ、各設定ファイルの `ignorePatterns`（`.gitignore` 構文）に追記する。レガシーな `.oxlintignore` / `.prettierignore` 形式は新規には作らない。
 
-## oxlint の主な設定項目
+## 設定項目の詳細
 
-- `rules`: ルール個別の有効化と無効化、重大度
-- `categories`: `correctness`、`suspicious`、`pedantic` などのカテゴリ単位の一括制御
-- `plugins`: 有効化するネイティブプラグイン一覧。指定するとデフォルトセットを上書きするため、デフォルトのプラグインに追加したいだけの場合はデフォルトのプラグインも含めて明記する
-- `overrides`: ファイルパターン別の設定上書き
-- `env` / `globals`: 環境変数とグローバル変数の宣言
+個々の設定項目は頻繁に追加・変更されるため、このファイルには列挙しない。設定を書く際は都度、公式のリファレンスを確認する。
 
-## oxfmt の主な設定項目
+- oxlint: https://oxc.rs/docs/guide/usage/linter/config-file-reference.html
+- oxfmt: https://oxc.rs/docs/guide/usage/formatter/config-file-reference.html
 
-Prettier とほぼ互換（`printWidth`、`semi`、`singleQuote`、`trailingComma` など）。
-oxfmt 独自の項目として `sortImports`（import 順序の自動整列）と `sortTailwindcss`（Tailwind CSS クラスの並び替え）があるが、移行元の Prettier 設定にはない項目のため、有効化するかどうかはユーザーに確認する。
+oxfmt には `sortImports`（import 順序の自動整列）や `sortTailwindcss`（Tailwind CSS クラスの並び替え）など、Prettier にはない項目がある。移行元の Prettier 設定には存在しない項目のため、有効化するかどうかはユーザーに確認する。

--- a/home/.agents/skills/personal-setup-oxc/references/editor.md
+++ b/home/.agents/skills/personal-setup-oxc/references/editor.md
@@ -1,0 +1,28 @@
+# エディタ拡張の設定
+
+oxlint と oxfmt は VS Code 拡張を共有する（拡張機能 ID: `oxc.oxc-vscode`）。
+
+## `.vscode/extensions.json`
+
+`recommendations` に追加する。
+
+```json
+{
+  "recommendations": ["oxc.oxc-vscode"]
+}
+```
+
+`esbenp.prettier-vscode` / `biomejs.biome` が含まれている場合は削除する。`dbaeumer.vscode-eslint` は、ESLint を並行運用する場合（[migration.md](migration.md)）を除き削除する。
+
+## `.vscode/settings.json`
+
+保存時フォーマットを有効化する場合は以下を追加する。
+
+```json
+{
+  "editor.defaultFormatter": "oxc.oxc-vscode",
+  "editor.formatOnSave": true
+}
+```
+
+`editor.defaultFormatter` が `esbenp.prettier-vscode` や `biomejs.biome` など他の値になっている場合は置き換える。

--- a/home/.agents/skills/personal-setup-oxc/references/migration.md
+++ b/home/.agents/skills/personal-setup-oxc/references/migration.md
@@ -1,0 +1,54 @@
+# 既存のリンターとフォーマッターからの移行
+
+## ESLint からの移行
+
+1. ESLint の設定形式を確認する。
+   - Flat Config（`eslint.config.js`/`.mjs`/`.ts` など、ESLint v9/v10）の場合はそのまま次に進む。
+   - レガシー設定（`.eslintrc.*`）の場合、`@oxlint/migrate` は非対応のため、先に公式ツールで Flat Config に変換する。
+     ```bash
+     npx @eslint/migrate-config .eslintrc.json
+     ```
+2. `@oxlint/migrate` で ESLint 設定を oxlint 設定に変換する。
+   ```bash
+   npx @oxlint/migrate eslint.config.js
+   ```
+   ネイティブ対応していないルールやプラグインは、`.oxlintrc.json` の `jsPlugins` として自動的に引き継がれる（この場合も ESLint 本体は不要になる）。
+3. 変換結果を確認し、方針を決める。
+   - ほぼすべてのルールが移行できた場合: ESLint 本体と関連パッケージ（`eslint`、使用していた `eslint-plugin-*`／`eslint-config-*` など）、`.eslintrc.*`、`eslint.config.*` を削除する。`package.json` にレガシーな `eslintConfig` フィールドが残っている場合はそれも削除する。
+   - `jsPlugins` でも移行できないプラグインがあり ESLint を残す必要がある場合: `eslint-plugin-oxlint` を導入し、oxlint が既にカバーしているルールを ESLint 側で無効化して二重に警告が出ないようにする。ESLint を残すかどうか、残す場合にどのルールのために残すかはユーザーに確認する。
+     ```bash
+     npm install --save-dev eslint-plugin-oxlint
+     ```
+     ESLint を残す場合、[SKILL.md](../SKILL.md) 手順6で置き換えた `lint` スクリプトはもう ESLint を実行しないため、`lint:eslint` などの専用スクリプトを別途追加し、`lint` から呼び出すか CI 側に呼び出しステップを追加して、ESLint のチェックが実行から漏れないようにする。
+
+## Prettier からの移行
+
+1. `oxfmt --migrate=prettier` で Prettier の設定を oxfmt 設定に変換する。
+   ```bash
+   npx oxfmt --migrate=prettier
+   ```
+2. `.prettierignore` があれば、内容を oxfmt 設定ファイルの `ignorePatterns` に統合する（詳細は [config.md](config.md)）。
+3. Prettier 本体と関連パッケージ（`prettier`、`eslint-plugin-prettier` など）を削除する。ESLint を並行運用しており、フォーマット関連ルールとの競合回避のために `eslint-config-prettier` が必要な場合はそのまま残す。
+   設定ファイル（`.prettierrc`、`.prettierrc.{json,yaml,yml,js,cjs,mjs}`、`prettier.config.{js,cjs,mjs}`）と `package.json` の `prettier` フィールドも、手順1で変換済みであれば削除する。
+4. コードベース中の `// prettier-ignore` コメントを `// oxfmt-ignore` に置き換える（JS/TS ファイルのみ対応）。
+5. oxfmt のデフォルト `printWidth` は 100（Prettier のデフォルトは 80）。この差などにより大きな整形差分が出ることがあるため、その場合は整形専用コミットを1つに分離し、`.git-blame-ignore-revs` への記録をユーザーに提案する。
+
+## Biome からの移行
+
+oxlint と oxfmt には Biome 設定を自動変換するツールは用意されていない。
+`biome.json`（または `biome.jsonc`）のリントルールとフォーマットオプションの内容を確認し、[config.md](config.md) に従って oxlint と oxfmt の設定に手動で移植する。移植後、Biome 本体（`@biomejs/biome`）と `biome.json`／`biome.jsonc` を削除する。
+
+## 共通: 移行後の消し残しチェック
+
+どのツールから移行した場合も、以下に旧ツール（ESLint／Prettier／Biome）への言及が残っていないか確認し、残っていれば oxlint と oxfmt を使うよう更新または削除する。
+
+- [ci.md](ci.md) に従って更新する CI ワークフロー
+- [editor.md](editor.md) に従って更新するエディタの拡張機能と設定
+- `package.json` の `lint` と `format` 以外のスクリプト（`check`、`format:write` など、旧ツールを直接呼び出しているもの）
+
+## モノレポの場合
+
+ESLint の設定は Flat Config とレガシー設定のいずれもパッケージごとに存在しうる。特にレガシー設定（`.eslintrc.*`）はディレクトリ単位でカスケードするため、ルートの設定ファイルだけでなく各パッケージの設定ファイルも確認し、存在する場合はパッケージごとに上記の変換手順を繰り返す。Prettier や Biome も設定ファイルがパッケージ単位で分かれている場合は同様に扱う。
+
+移行結果を踏まえた方針決定（ESLint を削除するか、`eslint-plugin-oxlint` を使って残すか）もパッケージごとに判断してよい。oxlint と oxfmt はルートから実行してもディレクトリごとに最も近い設定ファイルを適用するため（[config.md](config.md)）、パッケージによって方針が異なっていてもルートの `lint`／`format:check` 実行は1本のままでよい。
+ただし ESLint を残すパッケージがある場合、上記「ESLint からの移行」の手順3で追加する `lint:eslint` 相当のスクリプトは、そのパッケージの `package.json` に追加し、ルートの集約実行または CI から呼び出す。

--- a/home/.agents/skills/personal-setup-oxc/references/type-aware.md
+++ b/home/.agents/skills/personal-setup-oxc/references/type-aware.md
@@ -1,0 +1,35 @@
+# type-aware lint の有効化
+
+## 前提
+
+型情報を使ったルール（`await` し忘れた Promise、いわゆる floating promise の検出など）を有効化する。実行時は `oxlint-tsgolint`（tsgo ベース）が別プロセスとして型情報を解決するため、対象パッケージに解決可能な `tsconfig.json` が必要になる。
+
+## 有効化するかどうかの判断
+
+以下のいずれかに該当する場合は有効化を見送り、通常の（型情報を使わない）oxlint のみで運用する。判断に迷う場合はユーザーに確認する。モノレポの場合はパッケージごとにこの判断を行う。
+
+- 対象パッケージが TypeScript の Project References（`references` フィールド）で他パッケージに依存しており、依存先をビルドしないと `.d.ts` が揃わない。ビルドを CI や開発フローに組み込む余地がない場合は無効化する
+- `tsconfig.json` の `include` を絞り込めない（生成コードや大量の `.d.ts` を含むなど、構成上 `**/*` に近い範囲を含めざるを得ない）
+- パッケージがほぼ JavaScript のみで、型情報から得られる恩恵が小さい
+
+該当しなければ有効化する。
+
+## 手順
+
+1. `oxlint-tsgolint` を devDependencies としてインストールする。モノレポの場合はルートに1回だけインストールし、有効化するパッケージ間で共有する。
+2. 恒常的に有効化する場合は設定ファイルに書く（CLI の `--type-aware` はその場限りの切り替え用）。
+   ```json
+   {
+     "options": {
+       "typeAware": true
+     }
+   }
+   ```
+   モノレポでパッケージごとに有効化するかどうかが異なる場合は、ルートの設定ファイルではなく、有効化するパッケージ自身の設定ファイルに書く（[config.md](config.md) の「最も近い設定ファイルが優先される」仕組みにより、そのパッケージ配下だけに適用される）。
+
+## 注意
+
+- `tsconfig.json` の `include` が `**/*` のように広すぎると、不要なファイルまで型解決の対象になり大幅に遅くなる。[personal-setup-typescript スキル](../../personal-setup-typescript/SKILL.md)で作成した tsconfig であれば、通常は適切な `include` になっている。
+- モノレポで依存パッケージ側に型情報がない場合、あらかじめビルドして `.d.ts` を生成しておく必要がある（Project References を使っている場合は `tsgo -b` 相当のビルドを先に実行する）。
+- tsgo（TypeScript 7 相当）との互換性が前提。プロジェクトの `tsconfig.json` に TypeScript 6.0 で非推奨になり 7.0 で削除されたオプションが残っている場合は、[personal-setup-typescript スキル](../../personal-setup-typescript/SKILL.md)側で対応する。
+- 遅い場合は `OXC_LOG=debug oxlint --type-aware` でプログラムごとの処理時間を確認し、それでも改善しない場合は該当パッケージだけ無効化する。


### PR DESCRIPTION
## Why

We want a repeatable way to set up oxlint and oxfmt in a project, following the same shape as the existing `personal-setup-pnpm` / `personal-setup-typescript` skills.

## What

Add the `personal-setup-oxc` skill:

- Detect current state (package manager, monorepo, existing ESLint/Prettier/Biome, existing oxlint/oxfmt)
- Install oxlint and oxfmt
- Migrate from ESLint/Prettier/Biome if present, including per-package handling in monorepos
- Add `lint`/`format:check` scripts to `package.json`
- Decide whether to enable type-aware linting (`oxlint-tsgolint`)
- Configure the VS Code extension if `.vscode/` already exists
- Add `lint` and `format-check` CI jobs (creating a minimal workflow if none exists yet, since these are check-only jobs with no deploy/secrets involved)

## Notes

- Related to https://github.com/p-chan/dotfiles/issues/497, which tracks applying the same "create a minimal workflow if none exists" behavior to `personal-setup-typescript`'s CI step.
