### PR TITLE
feat(agents): allow minimal CI workflow in personal-setup-typescript

### DIFF
--- a/home/.agents/skills/personal-setup-typescript/references/ci.md
+++ b/home/.agents/skills/personal-setup-typescript/references/ci.md
@@ -1,9 +1,39 @@
 # CI への typecheck ジョブ追加
 
-`.github/workflows/` に lint やテストなどを実行する CI 全般のワークフローが存在する場合のみ、そのワークフローに `typecheck` ジョブを追加する。
-存在しない場合は何もしない（新規にワークフローファイルを作成しない）。
+## 既存の CI ワークフローがある場合
+
+`.github/workflows/` に lint やテストなどを実行する CI 全般のワークフローが存在する場合、そのワークフローに `typecheck` ジョブを追加する。
 
 - Node.js のセットアップ方法、パッケージマネージャー、キャッシュ設定など、既存の他ジョブのスタイルに合わせる
 - ジョブ内では、採用したパターンで追加した `typecheck` スクリプトを実行する
 
-モノレポの場合は [monorepo.md](monorepo.md) の「CI」を参照する。
+## 既存の CI ワークフローがない場合
+
+`.github/workflows/` に、`typecheck` を実行する最小限のワークフローを新規作成する。
+[personal-github-actions-best-practices スキル](../../personal-github-actions-best-practices/SKILL.md)に従い、`actions/checkout` などのバージョンを SHA で固定する。
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [<デフォルトブランチ>]
+  pull_request:
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<SHA> # <最新タグ>
+      - uses: actions/setup-node@<SHA> # <最新タグ>
+        with:
+          node-version-file: .node-version # 実際のファイルに合わせる
+      - run: <検出したパッケージマネージャーのインストールコマンド>
+      - run: <typecheck スクリプトの実行コマンド>
+```
+
+pnpm を使う場合の `pnpm/action-setup` の要否など、パッケージマネージャー固有のセットアップは検出した内容に合わせる（詳細は [personal-setup-pnpm スキル](../../personal-setup-pnpm/references/ci.md)を参照）。
+
+## モノレポの場合
+
+[monorepo.md](monorepo.md) の「CI」を参照する。


### PR DESCRIPTION
## Why

`personal-setup-oxc`'s `ci.md` already allows creating a minimal check-only workflow when no CI workflow exists yet, based on the reasoning that check-only workflows (lint/format/typecheck) carry low risk and are trivially revertible (just delete the file), unlike deployment workflows involving credentials and secrets. `personal-setup-typescript`'s `ci.md` still had the old "do nothing" policy for the `typecheck` job, which is inconsistent.

## What

- Added a "When no CI workflow exists" section to `personal-setup-typescript/references/ci.md`, mirroring the equivalent section in `personal-setup-oxc/references/ci.md` (minimal YAML example, reference to `personal-github-actions-best-practices`, pinning actions by SHA)
- Restructured the existing section into "When a CI workflow exists" for consistency

## Notes

- `personal-setup-pnpm`'s `ci.md` is intentionally out of scope, per the issue (pnpm has no lint/typecheck-equivalent check worth enforcing in CI)

Closes https://github.com/p-chan/dotfiles/issues/497