### PR TITLE
fix(starship): resolve custom.git_branch command timeout warning

### DIFF
--- a/home/.config/starship.toml
+++ b/home/.config/starship.toml
@@ -3,6 +3,7 @@
 format = "$character$directory${custom.git_branch}"
 right_format = "$time"
 add_newline = false
+command_timeout = 1000
 
 [character]
 format = "[⋊>](blue) "
@@ -13,7 +14,7 @@ format = "[$path](yellow) "
 fish_style_pwd_dir_length = 1
 
 [custom.git_branch]
-command = 'branch=$(git branch --show-current 2>/dev/null); dirty=$(git status --short 2>/dev/null | grep -q . && echo "*" || echo ""); echo "${branch}${dirty}"'
+command = 'out=$(git status --porcelain --branch 2>/dev/null); branch=$(printf "%s" "$out" | head -1 | sed -E "s/^## //; s/\.\.\..*//; s/ .*//"); [ "$(printf "%s\n" "$out" | wc -l)" -gt 1 ] && dirty="*" || dirty=""; printf "%s%s" "$branch" "$dirty"'
 when = 'git rev-parse --git-dir > /dev/null 2>&1'
 format = "on [$output](green) "
 


### PR DESCRIPTION
## Why

Switching to `main` triggered a starship warning:

```
[WARN] - (starship::modules::custom): Executing custom command "..." timed out.
```

`custom.git_branch` spawned three subprocesses per prompt render (`git branch`, `git status --short`, `grep`). Right after `git switch`/`checkout` to a branch with a large diff (like `main`), the working tree's mtimes are invalidated, so `git status` has to re-stat every file, which is slower than usual. Combined with the extra subprocess overhead and starship's default 500ms `command_timeout`, this pushed the command over the limit.

## What

- Consolidated the branch name + dirty check into a single `git status --porcelain --branch` call instead of two `git` invocations plus `grep`
- Raised `command_timeout` from the default 500ms to 1000ms for headroom

Output is unchanged (e.g. `on main*`).

## Notes

Confirmed via `STARSHIP_CONFIG=... starship prompt` that the rendered prompt is identical before and after the change.
