### PR TITLE
feat(agents): add personal-detect-git-convention

### DIFF
--- a/home/.agents/skills/personal-commit/SKILL.md
+++ b/home/.agents/skills/personal-commit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: personal-commit
 description: Git リポジトリのスタイルに合わせてコミットを作成します。ユーザーがコミットを求めたときや、エージェントがコミットするときに必ず使用してください。
-allowed-tools: Bash(git diff:*), Bash(git log:*), Bash(git config --local --get *), Bash(sed:*), Bash(tr:*), Bash(sort:*), Bash(xargs:*)
+allowed-tools: Bash(git diff:*), Bash(git log:*), Bash(git config --local --get *), Bash(sed:*), Bash(tr:*), Bash(sort:*), Bash(xargs:*), Bash(gh issue list *), Bash(gh pr list *), Bash(fd *), Read(*)
 ---
 
 # Git コミット作成
@@ -42,51 +42,17 @@ git diff
 
 ### 3. 判定
 
-#### キャッシュ確認
+[personal-detect-git-convention スキル](../personal-detect-git-convention/SKILL.md)の手順に従い、以下を判定します。
 
-まず以下のコマンドでキャッシュを確認します：
-
-```bash
-git config --local --get convention.language
-git config --local --get convention.commit-message
-```
-
-両方設定済みの場合はその値を使い、言語判定とスタイル判定をスキップします。
-
-未設定の項目がある場合は `git log --oneline -100` を実行し、言語判定とスタイル判定を行います。
-
-#### 言語判定
-
-| 言語   | パターン           | `convention.language` の値 |
-| ------ | ------------------ | -------------------------- |
-| 日本語 | 日本語が含まれる   | `ja`                       |
-| 英語   | 英語のみが含まれる | `en`                       |
-| その他 | 上記以外           | `others`                   |
-
-#### スタイル判定
-
-| スタイル                  | パターン                | `convention.commit-message` の値 |
-| ------------------------- | ----------------------- | -------------------------------- |
-| Conventional Commits      | `feat:`, `fix:` 等      | `conventional-commits`           |
-| gitmoji（Unicode 絵文字） | Unicode 絵文字で始まる  | `gitmoji-unicode`                |
-| gitmoji（Shortcode）      | `:sparkles:` 等で始まる | `gitmoji-shortcode`              |
-| その他                    | 上記以外                | `others`                         |
-
-#### キャッシュ保存
-
-判定結果をキャッシュに保存します。
-
-```bash
-git config --local convention.language <判定結果>
-git config --local convention.commit-message <判定結果>
-```
+- 言語（`convention.language`）
+- コミットメッセージスタイル（`convention.commit-message-style`）
 
 #### スコープ判定
 
 以下のコマンドでスコープ一覧を取得します。
 
 ```bash
-git log --oneline -n 999 | sed -n 's/^[a-f0-9]* [^(:]*(\([^)]*\)):.*/\1/p' | tr ',' '\n' | sed 's/^ *//' | sort -u | xargs | sed 's/ /, /g'
+git log --oneline -n 999 --perl-regexp --author='^((?!\[bot\]).)*$' | sed -n 's/^[a-f0-9]* [^(:]*(\([^)]*\)):.*/\1/p' | tr ',' '\n' | sed 's/^ *//' | sort -u | xargs | sed 's/ /, /g'
 ```
 
 出力が空の場合はスコープなしとして扱います。

--- a/home/.agents/skills/personal-create-pr/SKILL.md
+++ b/home/.agents/skills/personal-create-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: personal-create-pr
 description: GitHub の PR を作成します。ユーザーが PR の作成を求めたときや、エージェントが PR を作成するときに使用してください。
 compatibility: Claude Code
-allowed-tools: Bash(git config --local --get *), Bash(gh pr list *), Bash(git ls-remote *)
+allowed-tools: Bash(git config --local --get *), Bash(gh pr list *), Bash(git ls-remote *), Bash(git log:*), Bash(gh issue list *), Bash(fd *), Read(*)
 ---
 
 # GitHub PR 作成
@@ -11,46 +11,10 @@ allowed-tools: Bash(git config --local --get *), Bash(gh pr list *), Bash(git ls
 
 ### 1. 判定
 
-#### キャッシュ確認
+[personal-detect-git-convention スキル](../personal-detect-git-convention/SKILL.md)の手順に従い、以下を判定します。
 
-まず以下のコマンドでキャッシュを確認します：
-
-```bash
-git config --local --get convention.language
-git config --local --get convention.pull-request-title
-```
-
-両方設定済みの場合はその値を使い、言語判定とスタイル判定をスキップします。
-
-未設定の項目がある場合は、以下のコマンドを実行し、言語判定とスタイル判定を行います。
-
-```sh
-gh pr list --state all --limit 10 --json title,author --jq '[.[] | select(.author.login | test("\\[bot\\]$") | not) | .title]'
-```
-
-#### 言語判定
-
-| 言語   | パターン           | `convention.language` の値 |
-| ------ | ------------------ | -------------------------- |
-| 日本語 | 日本語が含まれる   | `ja`                       |
-| 英語   | 英語のみが含まれる | `en`                       |
-| その他 | 上記以外           | `others`                   |
-
-#### スタイル判定
-
-| スタイル             | パターン           | `convention.pull-request-title` の値 |
-| -------------------- | ------------------ | ------------------------------------ |
-| Conventional Commits | `feat:`, `fix:` 等 | `conventional-commits`               |
-| その他               | 上記以外           | `others`                             |
-
-#### キャッシュ保存
-
-判定結果をキャッシュに保存します。
-
-```bash
-git config --local convention.language <判定結果>
-git config --local convention.pull-request-title <判定結果>
-```
+- 言語（`convention.language`）
+- PR タイトルスタイル（`convention.pull-request-title-style`）
 
 ### 2. テンプレート確認
 
@@ -87,7 +51,7 @@ git diff <base-branch>...HEAD
 タイトルと本文を生成する前に、生成に使う設定値を出力します。
 
 - 言語: `<convention.language の値>`
-- スタイル: `<convention.pull-request-title の値>`
+- スタイル: `<convention.pull-request-title-style の値>`
 - テンプレート: `<テンプレートのパス or なし>`
 
 その後、言語とスタイル、テンプレート、差分をもとに、タイトルと本文を生成します。

--- a/home/.agents/skills/personal-detect-git-convention/SKILL.md
+++ b/home/.agents/skills/personal-detect-git-convention/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: personal-detect-git-convention
+description: 各リポジトリの既存の慣習からコミットメッセージ・PR タイトルの言語/スタイルを検出し、それに従うための手順をまとめたリファレンスです。ユーザーが Git の規約について尋ねたときや、他のスキルがコミット・PR 作成時に規約判定を必要とするときに使用してください。
+allowed-tools: Bash(git config --local --get *), Bash(git config --local convention.language *), Bash(git config --local convention.commit-message-style *), Bash(git config --local convention.pull-request-title-style *), Bash(git log:*), Bash(gh pr list *), Bash(gh issue list *), Bash(fd *), Read(*)
+---
+
+# Git 規約の検出
+
+コミットメッセージ・PR タイトルについて、特定のスタイルを一律に強制するのではなく、対象リポジトリの `git log` や既存 PR から実際の慣習を検出し、それに従うための手順をまとめたリファレンスです。
+
+## キャッシュキー一覧
+
+| キー                                  | 意味                                      | 取りうる値                                                                                      |
+| ------------------------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `convention.language`                 | コミットメッセージ・PR タイトルなどの言語 | `ja` / `en` / `others:<説明>` / `others:?`                                                      |
+| `convention.commit-message-style`     | コミットメッセージのスタイル              | `conventional-commits` / `gitmoji-unicode` / `gitmoji-shortcode` / `others:<説明>` / `others:?` |
+| `convention.pull-request-title-style` | PR タイトルのスタイル                     | `conventional-commits` / `others:<説明>` / `others:?`                                           |
+
+## 判定の共通手順
+
+判定結果は `git config --local` を使ってリポジトリごとにキャッシュし、同じリポジトリでの再判定を避けます。
+
+### 1. キャッシュ確認
+
+判定したいキーについて、以下のコマンドでキャッシュを確認します。
+
+```bash
+git config --local --get convention.<key>
+```
+
+対象のキーがすべて設定済みの場合はその値を使い、判定をスキップします。
+
+未設定のキーがある場合は、下記の各セクションで定義した情報源と基準を使って判定します。
+
+### 2. キャッシュ保存
+
+判定後、以下のコマンドで結果を保存します。
+
+```bash
+git config --local convention.<key> <判定結果>
+```
+
+判定結果が「その他」に該当する場合は、常に `others:` の形式で保存します。コロンの後ろは、検出した内容に一貫した法則があるかどうかで書き分けます。
+
+| 状況                                     | 保存形式              |
+| ---------------------------------------- | --------------------- |
+| 独自だが一貫した法則を検出できた         | `others:<法則の説明>` |
+| 特に一貫した法則が見られない（バラバラ） | `others:?`            |
+
+一貫した法則がある場合は、次回キャッシュを読んだときに再度 `git log` などを調べ直さなくて済むよう、検出した内容を残します。
+
+```bash
+git config --local convention.commit-message-style "others:no-prefix, imperative mood"
+```
+
+一貫した法則が見られない場合、無理に説明を書いても意味がないため `?` を保存します。
+
+```bash
+git config --local convention.commit-message-style others:?
+```
+
+## 言語判定（`convention.language`）
+
+以下の情報源を横断的に確認し、総合的に判定します。存在しない、または空の情報源は無視します。
+
+| 情報源             | コマンド                                                                                                                             |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| README             | `fd -u -d 1 -i readme` で見つけたファイルを読む                                                                                      |
+| コミットメッセージ | `git log --oneline -10 --perl-regexp --author='^((?!\[bot\]).)*$'`                                                                   |
+| Issue              | `gh issue list --state all --limit 10 --json title --jq '[.[].title]'`                                                               |
+| PR                 | `gh pr list --state all --limit 10 --json title,author --jq '[.[] \| select(.author.login \| test("\\[bot\\]$") \| not) \| .title]'` |
+
+判定基準:
+
+| 言語   | パターン           | 値                             |
+| ------ | ------------------ | ------------------------------ |
+| 日本語 | 日本語が含まれる   | `ja`                           |
+| 英語   | 英語のみが含まれる | `en`                           |
+| その他 | 上記以外           | `others:<言語名>` / `others:?` |
+
+複数の情報源の判定結果が一致する場合は、その言語を採用します。
+
+以下の場合は、無理に判定を確定させず、ユーザーに直接質問して言語を決定します。
+
+- どの情報源からも言語を判断できる材料がなかった（README なし、コミット・Issue・PR もない、など）
+- 情報源ごとに判定結果がバラバラで、優勢な言語が定まらない
+
+## コミットメッセージスタイル判定（`convention.commit-message-style`）
+
+`git log --oneline -10 --perl-regexp --author='^((?!\[bot\]).)*$'` を情報源とします。
+
+| スタイル                  | パターン                | 値                                             |
+| ------------------------- | ----------------------- | ---------------------------------------------- |
+| Conventional Commits      | `feat:`, `fix:` 等      | `conventional-commits`                         |
+| gitmoji（Unicode 絵文字） | Unicode 絵文字で始まる  | `gitmoji-unicode`                              |
+| gitmoji（Shortcode）      | `:sparkles:` 等で始まる | `gitmoji-shortcode`                            |
+| その他                    | 上記以外                | `others:<検出したスタイルの説明>` / `others:?` |
+
+## PR タイトルスタイル判定（`convention.pull-request-title-style`）
+
+`gh pr list --state all --limit 10 --json title,author --jq '[.[] | select(.author.login | test("\\[bot\\]$") | not) | .title]'` を情報源とします。
+
+| スタイル             | パターン           | 値                                             |
+| -------------------- | ------------------ | ---------------------------------------------- |
+| Conventional Commits | `feat:`, `fix:` 等 | `conventional-commits`                         |
+| その他               | 上記以外           | `others:<検出したスタイルの説明>` / `others:?` |


### PR DESCRIPTION
## Why

`personal-commit` and `personal-create-pr` each duplicated the same
language/style detection logic and git-config caching mechanics
(`convention.language`, `convention.commit-message`,
`convention.pull-request-title`). Keeping the detection rules in two
places made them easy to drift apart and harder to update.

## What

- Add `personal-detect-git-convention`, a reference skill that owns
  the detection rules and `git config --local` caching for:
  - `convention.language` (judged from README, commit messages,
    Issues, and PRs combined; asks the user when signals are missing
    or inconsistent)
  - `convention.commit-message-style` (judged from `git log`)
  - `convention.pull-request-title-style` (judged from `gh pr list`)
- Exclude bot-authored commits/PRs from the detection sources, and
  cap the commit-message sample to 10 to limit processing cost.
- Rewire `personal-commit` and `personal-create-pr` to defer to the
  new skill instead of duplicating the tables and cache logic.
- Rename the ambiguous `others` value to `others:<description>` (or
  `others:?` when no consistent pattern is found) so a cache hit
  still carries useful information on the next read.

## Notes

Branch naming rules were considered for inclusion but kept in
`personal-create-branch`, since they can't be detected from repo
history the way language/style can — they're a fallback default
rather than something to detect.