### PR TITLE
feat(agents,zsh): add worktree-based development support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,10 @@ P-Chan's portable dev environment as code.
 - Shell scripts
 - Deno
 
+## Git
+
+- Do not use worktrees in this repository (`convention.use-worktree: false`). Files under `home/` are live configuration referenced via symlinks from the home directory, so changes made in a worktree take no effect. Switch branches in the current working tree instead.
+
 ## Verification
 
 - `scripts/doctor.sh`: Check existence of required commands

--- a/home/.agents/skills/personal-create-branch/SKILL.md
+++ b/home/.agents/skills/personal-create-branch/SKILL.md
@@ -1,26 +1,40 @@
 ---
 name: personal-create-branch
-description: Git リポジトリの慣習に則って新しいブランチを作成します。ユーザーがブランチの作成を求めたときや、エージェントが `git branch` や `git checkout -b`、`git switch -c` などを用いてブランチを作成するときに必ず使用してください。
-allowed-tools: Bash(git status), Bash(git status *), Bash(git diff), Bash(git diff *)
+description: Git リポジトリの慣習に則って新しいブランチや worktree を作成します。ユーザーがブランチや worktree の作成を求めたときや、エージェントが `git branch` や `git switch -c`、`git worktree add` などを用いて新しい作業を開始するときに必ず使用してください。
+allowed-tools: Bash(git status), Bash(git status *), Bash(git diff), Bash(git diff *), Bash(git config --local --get *)
 ---
 
-# Git ブランチ作成
+# Git ブランチ・worktree 作成
 
 ## 前提
 
-メモリファイル（`AGENTS.md` や `CLAUDE.md` など）にブランチ名の規約がある場合は、メモリファイルに従う。
+メモリファイル（`AGENTS.md` や `CLAUDE.md` など）にブランチ名の規約がある場合は、メモリファイルに従います。
 
 ## ワークフロー
 
-### 1. 情報収集
+### 1. worktree 運用の確認
 
-今までのコンテキストをもとに、ブランチの目的を理解します。
+[personal-detect-git-convention スキル](../personal-detect-git-convention/SKILL.md)の手順に従い、`convention.use-worktree` を確認します。
 
-コンテキストが不足している場合は `git status` や `git diff` で情報収集して、ブランチの目的を理解します。
+```bash
+git config --local --get convention.use-worktree
+```
 
-### 2. ブランチ名生成
+- `true` の場合: worktree を作成します（ステップ 4-a）
+- `false` の場合: 現在の working tree にブランチを作成します（ステップ 4-b）
+- 未設定の場合: personal-detect-git-convention スキルの手順で判定・キャッシュしてから、その結果に従います
 
-ブランチの目的をもとに 2〜5 単語程度のブランチ名を生成します。
+worktree を使うかどうかは、常に規約に従って判断します。「ブランチを作って」のような依頼は、worktree を使うかどうかの指定ではありません（worktree の作成はブランチの作成を兼ねます）。規約より優先するのは、ユーザーが worktree を使う・使わないに直接言及した場合だけです。
+
+### 2. 情報収集
+
+今までのコンテキストをもとに、作業の目的を理解します。
+
+コンテキストが不足している場合は `git status` や `git diff` で情報収集して、作業の目的を理解します。
+
+### 3. ブランチ名生成
+
+作業の目的をもとに 2〜5 単語程度のブランチ名を生成します。
 
 - 動詞で始める（`add`、`update`、`fix`、`remove` など）
 - スラッシュを使わない
@@ -34,7 +48,20 @@ allowed-tools: Bash(git status), Bash(git status *), Bash(git diff), Bash(git di
 - update-baz
 - remove-qux
 
-### 3. ブランチ作成
+### 4-a. worktree 作成
+
+生成されたブランチ名を表示し、worktree を作成します。ブランチが存在しない場合は、ブランチも同時に作成されます。
+
+```bash
+git wt <branch-name>
+```
+
+`git wt` は作成した worktree のパスを出力します。以降の作業は、出力されたパスに移動して行います。
+
+> [!NOTE]
+> シェル統合が有効なインタラクティブシェルでは自動で移動しますが、エージェントの実行環境では自動で移動しないため、明示的に `cd` してください。
+
+### 4-b. ブランチ作成
 
 生成されたブランチ名を表示し、ブランチを作成します。
 

--- a/home/.agents/skills/personal-detect-git-convention/SKILL.md
+++ b/home/.agents/skills/personal-detect-git-convention/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: personal-detect-git-convention
 description: 各リポジトリの既存の慣習からコミットメッセージ・PR タイトルの言語/スタイルを検出し、それに従うための手順をまとめたリファレンスです。ユーザーが Git の規約について尋ねたときや、他のスキルがコミット・PR 作成時に規約判定を必要とするときに使用してください。
-allowed-tools: Bash(git config --local --get *), Bash(git config --local convention.language *), Bash(git config --local convention.commit-message-style *), Bash(git config --local convention.pull-request-title-style *), Bash(git config --local convention.branch-strategy *), Bash(git log:*), Bash(gh pr list *), Bash(gh issue list *), Bash(gh repo view *), Bash(gh api repos/*/branches/*/protection*), Bash(fd *), Read(*)
+allowed-tools: Bash(git config --local --get *), Bash(git config --local convention.language *), Bash(git config --local convention.commit-message-style *), Bash(git config --local convention.pull-request-title-style *), Bash(git config --local convention.branch-strategy *), Bash(git config --local convention.use-worktree *), Bash(git log:*), Bash(gh pr list *), Bash(gh issue list *), Bash(gh repo view *), Bash(gh api repos/*/branches/*/protection*), Bash(fd *), Read(*)
 ---
 
 # Git 規約の検出
@@ -16,6 +16,7 @@ allowed-tools: Bash(git config --local --get *), Bash(git config --local convent
 | `convention.commit-message-style`     | コミットメッセージのスタイル              | `conventional-commits` / `gitmoji-unicode` / `gitmoji-shortcode` / `others:<説明>` / `others:?` |
 | `convention.pull-request-title-style` | PR タイトルのスタイル                     | `conventional-commits` / `others:<説明>` / `others:?`                                           |
 | `convention.branch-strategy`          | デフォルトブランチへの直接コミットの可否  | `direct-commit` / `pull-request` / `others:?`                                                   |
+| `convention.use-worktree`             | worktree 運用の可否                       | `true` / `false`                                                                                |
 
 ## 判定の共通手順
 
@@ -129,3 +130,10 @@ gh api repos/{owner}/{repo}/branches/<デフォルトブランチ名>/protection
 | 200（保護ルールあり）                                         | デフォルトブランチへの直接コミットが制限されている | `pull-request`             |
 | 404（保護ルールなし）                                         | デフォルトブランチへの直接コミットが許容されている | `direct-commit`            |
 | 上記以外（GitHub 以外のホスティング、権限不足、通信エラー等） | 自動判定不可                                       | ユーザーに直接質問して決定 |
+
+## worktree 運用判定（`convention.use-worktree`）
+
+通常の開発作業を worktree で行うかどうかの判定です。他のキーと異なり履歴から自動判定できないため、以下の順で決定します。
+
+1. メモリファイル（`AGENTS.md` や `CLAUDE.md` など）に worktree 運用についての記載があれば、それに従います
+2. 記載がなければ、ユーザーに質問して決定します

--- a/home/.agents/skills/personal-merge-pr/SKILL.md
+++ b/home/.agents/skills/personal-merge-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: personal-merge-pr
 description: ユーザーが PR のマージを求めたときや、エージェントが PR をマージするときに必ず使用してください。
-allowed-tools: Bash(gh review-comment list *), Bash(gh pr checks), Bash(gh repo view *), Bash(git fetch), Bash(git log *)
+allowed-tools: Bash(gh review-comment list *), Bash(gh pr checks), Bash(gh repo view *), Bash(git fetch), Bash(git log *), Bash(git rev-parse *)
 ---
 
 # GitHub PR マージ
@@ -89,7 +89,39 @@ gh pr view --json title -q .title
 - Rebase: `--rebase` オプション
 - Squash: `--squash` オプション
 
-また `--delete-branch` オプションを付けてマージと同時にブランチを削除します（このオプションを使うと、自動でベースブランチに切り替わります）。
+マージ時・マージ後の後片付けは、現在のディレクトリが linked worktree かどうかで手順が変わります。以下のコマンドで判定します。
+
+```sh
+test "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" && echo "linked worktree" || echo "main working tree"
+```
+
+#### main working tree の場合
+
+`--delete-branch` オプションを付けてマージと同時にブランチを削除します（このオプションを使うと、自動でベースブランチに切り替わります）。
 
 > [!WARNING]
 > `--repo` オプションは `--delete-branch` オプションを無効化するため、他リポジトリの PR をマージするときに限り、使用します。
+
+#### linked worktree の場合
+
+`--delete-branch` オプションは付けません。ベースブランチが別の worktree でチェックアウトされているため、マージ後のブランチ切り替えに失敗します。
+
+マージ後、マージしたブランチ名（`git branch --show-current`）を控えたうえで、以下の手順で worktree とローカルブランチを削除します。
+
+```sh
+# main working tree に移動する
+cd "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
+
+# worktree とローカルブランチを削除する
+git wt -d <branch-name>
+```
+
+リモートブランチは、リポジトリの Automatically delete head branches 設定が有効なら自動で削除されます。以下のコマンドで確認し、`false` の場合のみ手動で削除します。
+
+```sh
+gh repo view --json deleteBranchOnMerge -q .deleteBranchOnMerge
+```
+
+```sh
+git push origin --delete <branch-name>
+```

--- a/home/.config/zsh/.zshrc
+++ b/home/.config/zsh/.zshrc
@@ -95,25 +95,32 @@ function reload() {
   source "${ZDOTDIR:-$HOME}/.zshrc"
 }
 
-function _gh_pr_fuzzy_checkout() {
-  number=$(
+# PR ごとに worktree を作成して移動する（fork からの PR は非対応）
+# convention.use-worktree=false のリポジトリでは gh pr checkout にフォールバックする
+function _gh_pr_fuzzy_worktree() {
+  selected=$(
     GH_FORCE_TTY=100% \
     gh pr list --limit 100 \
     --json number,title,headRefName,isDraft \
     --template '{{range .}}{{ $color := "green" }}{{if .isDraft}}{{ $color = "black+h" }}{{end}}{{tablerow (color $color (printf "#%.0f" .number)) .title (color "cyan" .headRefName)}}{{end}}{{tablerender}}' \
-    | fzf --ansi \
-    | awk '{print $1}' \
-    | sed 's/^#//'
+    | fzf --ansi
   )
 
-  if [[ -n "$number" ]]; then
-    BUFFER="gh pr checkout $number"
+  if [[ -n "$selected" ]]; then
+    number=$(echo "$selected" | awk '{print $1}' | sed 's/^#//')
+    if [[ "$(git config --local --get convention.use-worktree 2>/dev/null)" == "false" ]]; then
+      BUFFER="gh pr checkout $number"
+    else
+      # 表示上の headRefName は truncate されうるので、API から正確な値を取得する
+      branch=$(gh pr view "$number" --json headRefName -q .headRefName)
+      BUFFER="git fetch origin && git wt ${(q)branch}"
+    fi
     zle accept-line
   fi
 }
 
-zle -N _gh_pr_fuzzy_checkout
-bindkey "^P" _gh_pr_fuzzy_checkout
+zle -N _gh_pr_fuzzy_worktree
+bindkey "^P" _gh_pr_fuzzy_worktree
 
 function _ghq_fuzzy_cd() {
   local root=$(ghq root)


### PR DESCRIPTION
## Why

Development is moving to a git-wt worktree-based workflow, but the agent skills and shell shortcuts assumed a single working tree: branches were created with `git switch -c`, merges used `gh pr merge --delete-branch` (which fails when the base branch is checked out in another worktree), and Ctrl-P ran `gh pr checkout`, switching the current working tree. At the same time, not every repository should use worktrees — this dotfiles repository is referenced live via symlinks, so changes made in a worktree take no effect.

## What

- Add a `convention.use-worktree` key to the personal-detect-git-convention skill. It cannot be detected from history, so it is resolved from memory files or by asking the user, then cached like the other convention keys.
- personal-create-branch: create a worktree with `git wt` when the convention is `true`, or a plain branch when `false`. A request to "create a branch" alone does not specify worktree usage (creating a worktree also creates a branch), so the convention always decides unless the user directly mentions worktrees.
- personal-merge-pr: detect a linked worktree at runtime, merge without `--delete-branch`, clean up with `git wt -d`, and delete the remote branch only when the repository does not auto-delete merged branches.
- Ctrl-P: switch to the selected PR's worktree with `git wt`, falling back to `gh pr checkout` in repositories with `convention.use-worktree=false`. The branch name is resolved from the PR number via the API because the displayed column can be truncated, and quoted with `${(q)...}` because PR authors control it.
- AGENTS.md: declare `convention.use-worktree: false` for this repository so convention detection resolves it on fresh clones without asking.

## Notes

- The merge-pr cleanup flow (worktree detection, moving to the main working tree, `git wt -d`) was verified against a temporary repository.
- `gh pr merge` remains unchanged for repositories that do not use worktrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpvhAUou1mh1usfpJCCTvH