### PR TITLE
fix(claude): use Edit deny rule instead of Write for .env protection

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -60,10 +60,10 @@
     "deny": [
       "Bash(git add -A)",
       "Bash(sudo *)",
+      "Edit(.env*)",
+      "Edit(!.env*.example)",
       "Read(.env*)",
-      "Read(!.env*.example)",
-      "Write(.env*)",
-      "Write(!.env*.example)"
+      "Read(!.env*.example)"
     ],
     "defaultMode": "auto"
   },


### PR DESCRIPTION
## Why

Claude Code emitted a startup warning that `Write(.env*)` isn't matched by file permission checks:

```
Permission deny rule (.claude/settings.json): Write(.env*) is not matched by file permission checks — only Edit(path) rules are. Use Edit(.env*) instead (Edit rules cover all file-editing tools).
```

Only `Edit(path)` rules cover all file-editing tools, including Write.

## What

Replace the `Write(.env*)` / `Write(!.env*.example)` deny rules with `Edit(.env*)` / `Edit(!.env*.example)`.

## Notes

None.
