### PR TITLE
feat(claude): deny direct Edit/Write on ~/.npmrc

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -63,7 +63,11 @@
       "Edit(.env*)",
       "Edit(!.env*.example)",
       "Read(.env*)",
-      "Read(!.env*.example)"
+      "Read(!.env*.example)",
+      "Edit(~/.npmrc)",
+      "Write(~/.npmrc)",
+      "Edit(~/.npmrcs/*)",
+      "Write(~/.npmrcs/*)"
     ],
     "defaultMode": "auto"
   },

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -65,9 +65,7 @@
       "Read(.env*)",
       "Read(!.env*.example)",
       "Edit(~/.npmrc)",
-      "Write(~/.npmrc)",
-      "Edit(~/.npmrcs/*)",
-      "Write(~/.npmrcs/*)"
+      "Write(~/.npmrc)"
     ],
     "defaultMode": "auto"
   },


### PR DESCRIPTION
## Why

Claude Code once ran `npm config set //npm.pkg.github.com/:_authToken "$(gh auth token -h github.com)"` as a side effect of an unrelated task, writing a global, unscoped auth token into `~/.npmrc`. That entry silently coexisted with the correct per-scope tokens for weeks, then broke `pnpm install` for `@pocopack` packages.

`npm config set` / `pnpm config set` themselves are safe to leave unrestricted since they only append/update a single key. The real risk is a direct `Edit`/`Write` tool call rewriting the whole file, which could drop other scopes' token lines entirely.

## What

- Add `Edit(~/.npmrc)`, `Write(~/.npmrc)`, `Edit(~/.npmrcs/*)`, `Write(~/.npmrcs/*)` to `permissions.deny` in `home/.claude/settings.json`, matching the existing `.env` protection style.

## Notes

`~/.npmrcs/*` covers the profile files behind the `npmrc` (npm:npmrc) symlink switcher tool that `~/.npmrc` points to.
