### PR TITLE
fix(mise): make bootstrap task idempotent for yazi packages

### DIFF
--- a/home/.config/mise/tasks/bootstrap
+++ b/home/.config/mise/tasks/bootstrap
@@ -43,9 +43,15 @@ if [ "${CI:-}" != "true" ]; then
 fi
 
 if type ya >/dev/null 2>&1; then
+  # `ya pkg add` exits non-zero for an already-registered package, so skip
+  # entries `ya pkg list` already reports to keep this task idempotent.
+  registered_packages="$(ya pkg list 2>/dev/null || true)"
   while IFS= read -r package; do
     case "$package" in
       ''|'#'*) continue ;;
+    esac
+    case "$registered_packages" in
+      *"$package"*) continue ;;
     esac
     ya pkg add "$package"
   done < "$DOTFILES_DIR/home/.config/yazi/packages.txt"


### PR DESCRIPTION
## Why

Running `mise bootstrap --yes` a second time on an already-converged machine (the normal case, since the bootstrap task runs on every invocation) died in the yazi step: `ya pkg add` exits non-zero when the package is already registered in `package.toml`, which aborts the task under `set -e`. mise's own docs require the `bootstrap` task to be idempotent.

## What

Skip `packages.txt` entries that `ya pkg list` already reports before calling `ya pkg add`.

## Notes

Verified with `CI=true bash home/.config/mise/tasks/bootstrap` on a converged machine: exits 0, the registered yazi plugin is skipped, and the gh/apm steps stay no-ops.

The dockutil restart-noise fix that used to be in this PR moved to its own PR, since it's a separate logical change and squash-merge makes PR granularity the commit granularity on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4s3Pd4W7CbGA3HzCb9cd9