### PR TITLE
fix(mise): restart Dock once after rebuilding it

### DIFF
--- a/home/.config/mise/tasks/bootstrap
+++ b/home/.config/mise/tasks/bootstrap
@@ -34,10 +34,14 @@ if [ "${CI:-}" != "true" ]; then
 
   defaultbrowser browser
 
-  dockutil --remove all
+  # --no-restart defers the Dock restart to a single killall at the end;
+  # restarting per invocation races the relaunch and spams
+  # "No matching processes belonging to you were found" from killall.
+  dockutil --remove all --no-restart
   for app in Fantastical Mimestream Arc Slack Figma 1Password "Visual Studio Code" Ghostty; do
-    [ -d "/Applications/$app.app" ] && dockutil --add "/Applications/$app.app"
+    [ -d "/Applications/$app.app" ] && dockutil --add "/Applications/$app.app" --no-restart
   done
+  killall Dock
 
   chflags nohidden ~/Library
 fi


### PR DESCRIPTION
## Why

The bootstrap task rebuilds the Dock with one dockutil invocation per app, and dockutil restarts the Dock (`killall Dock`) after every invocation by default. Rebuilding the Dock app-by-app therefore killed it 9 times and raced its own relaunch, spamming "No matching processes belonging to you were found" from killall once per app.

## What

Pass `--no-restart` to every dockutil call and restart the Dock once at the end, so the finished plist is picked up by a single relaunch.

## Notes

Split out of #516 — separate logical change, and squash-merge makes PR granularity the commit granularity on main. The exact `--no-restart` + single `killall Dock` sequence was exercised manually on this machine earlier today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4s3Pd4W7CbGA3HzCb9cd9