### PR TITLE
fix(brew): declare tap trust for codexbar in Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,6 @@
-tap "steipete/tap"
+# Homebrew requires non-official taps to be explicitly trusted (tap trust);
+# trust only the cask we actually use instead of the whole tap.
+tap "steipete/tap", trusted: { cask: "codexbar" }
 # eza can't be mise-managed: it ships no macOS binaries on GitHub Releases
 # (so github: fails), and mise's brew backend can't link its ca-certificates
 # dependency on machines where Homebrew already provides that file.


### PR DESCRIPTION
## Why

Homebrew's new [tap trust](https://docs.brew.sh/Tap-Trust) mechanism ignores formulae and casks from non-official taps until they are explicitly trusted. `dots up` therefore stopped upgrading codexbar and printed a trust warning on every run.

## What

Declare item-level trust on the tap entry per the [Brewfile `trusted` syntax](https://docs.brew.sh/Brew-Bundle-and-Brewfile):

```ruby
tap "steipete/tap", trusted: { cask: "codexbar" }
```

Only codexbar is trusted, not the whole tap, per Homebrew's recommendation. Declaring it in the Brewfile (instead of a one-off `brew trust`) keeps the trust state as code — `brew bundle cleanup --force` even resets the trust file to the declared values.

## Notes

Verified locally: the Brewfile parses (`brew bundle list`/`check`), and `brew bundle install` applied the trust — `brew trust` now reports `steipete/tap/codexbar` under trusted casks while the rest of the tap stays untrusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4s3Pd4W7CbGA3HzCb9cd9