### PR TITLE
docs: instruct updating macOS before running install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@
 
 ## Install
 
+Before anything else, open **System Settings > General > Software Update**
+and update macOS to the latest version. On a brand-new Mac (or one that was
+just reinstalled), the update catalog can be stale and block jumping straight
+to the latest version — if that happens, install the
+[full installer](https://support.apple.com/en-us/HT201475) or step through
+the intermediate versions it offers first.
+
 ```sh
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/p-chan/dotfiles/main/scripts/install.sh)"
 ```


### PR DESCRIPTION
## Summary
- New/reinstalled Macs can have a stale Software Update catalog that blocks jumping straight to the latest macOS, which was hit while setting up a new machine
- Add a note at the top of the Install section pointing users at System Settings and the full installer as a workaround

## Test plan
- [ ] Docs-only change; reviewed README rendering