### PR TITLE
docs: add troubleshooting note for cask checksum mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ so plain `mise bootstrap` invocations need no environment setup afterwards.
 To move the checkout later, move the directory and re-run `install.sh` with
 `DOTFILES_DIR` pointing at the new path.
 
+## Troubleshooting
+
+### `brew bundle` fails with "Cask reports different checksum"
+
+Some casks (e.g. `codexbar`) are auto-updating apps whose upstream release
+can be swapped in place under the same version tag. If `mise bootstrap` (or
+`brew bundle`) hits this error, the tap's recorded checksum is momentarily
+behind the file actually being served. Re-run `brew update` to pull the
+tap's latest commit, then retry — the checksum is usually corrected within a
+short time of the upstream release going out.
+
 ## Setup
 
 ### 1Password


### PR DESCRIPTION
## Summary
- `mise bootstrap` failed on a fresh Mac with `brew bundle` reporting "Cask reports different checksum" for `codexbar`
- Root cause: the tap's recorded checksum was momentarily behind the file actually being served upstream (auto-updating app, same version tag). Re-running `brew update` and retrying resolved it — the tap had already been corrected by the time of the retry
- Add a Troubleshooting section to README documenting the symptom and fix so it isn't mistaken for a broken Brewfile entry

## Test plan
- [ ] Docs-only change; reviewed README rendering
- [x] Reproduced the fix locally: `brew tap steipete/tap` + `brew install --cask steipete/tap/codexbar` succeeded after the tap picked up the corrected checksum