### PR TITLE
fix(mise): authenticate gh before installing github: tools

### DIFF
--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -49,10 +49,14 @@ dotfiles.default_mode = "symlink"
 [settings.github]
 # credential_command runs with mise's own shims stripped from PATH (to avoid
 # recursive mise invocations), so a bare `gh` wouldn't resolve — gh is only
-# ever installed as a mise shim here. `mise which gh` finds the real
-# executable; wrapping it in `$(...)` re-resolves it on every call so this
-# keeps working across `gh`'s "latest" upgrades without a hardcoded path.
-credential_command = "$(mise which gh) auth token"
+# ever installed as a mise shim here. Calling `mise which gh` from inside
+# credential_command would work around that, but mise's own docs warn
+# against it: gh is itself github:cli/cli, so resolving it could need a
+# GitHub token too, recursing back into this same credential_command. mise's
+# github backend keeps a `latest` symlink next to the resolved version
+# (e.g. installs/github-cli-cli/latest -> ./2.96.0) that it repoints on every
+# upgrade, so this path stays valid without invoking mise at all.
+credential_command = "$HOME/.local/share/mise/installs/github-cli-cli/latest/bin/gh auth token"
 
 [bootstrap.packages]
 "brew:defaultbrowser" = "latest"

--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -47,7 +47,12 @@ idiomatic_version_file_enable_tools = ['node']
 dotfiles.default_mode = "symlink"
 
 [settings.github]
-credential_command = "gh auth token"
+# credential_command runs with mise's own shims stripped from PATH (to avoid
+# recursive mise invocations), so a bare `gh` wouldn't resolve — gh is only
+# ever installed as a mise shim here. `mise which gh` finds the real
+# executable; wrapping it in `$(...)` re-resolves it on every call so this
+# keeps working across `gh`'s "latest" upgrades without a hardcoded path.
+credential_command = "$(mise which gh) auth token"
 
 [bootstrap.packages]
 "brew:defaultbrowser" = "latest"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -202,7 +202,23 @@ if type mise &>/dev/null; then
     # home/.config/gh/config.yml (git_protocol = ssh), so force https here to
     # skip the SSH key detection/upload prompt, which would otherwise depend
     # on 1Password's SSH agent already being set up.
+    #
+    # Log in through a scratch GH_CONFIG_DIR rather than the real
+    # ~/.config/gh: --git-protocol makes gh write a full config.yml, but that
+    # path is a dotfiles-managed symlink created later in the dotfiles phase
+    # below. Writing there first would conflict with that symlink on a first
+    # install, or silently overwrite the checked-in file through it on a
+    # re-run. Only hosts.yml (gh's auth reference; the token itself lives in
+    # the system keychain) needs to land in the real location, and it isn't
+    # dotfiles-managed, so copying it there directly is safe.
+    GH_AUTH_TMP_CONFIG_DIR="$(mktemp -d)"
+
+    GH_CONFIG_DIR="$GH_AUTH_TMP_CONFIG_DIR" \
     mise exec "github:cli/cli@latest" -- gh auth login --git-protocol https --skip-ssh-key
+
+    mkdir -p "$XDG_CONFIG_DIR/gh"
+    cp "$GH_AUTH_TMP_CONFIG_DIR/hosts.yml" "$XDG_CONFIG_DIR/gh/hosts.yml"
+    rm -rf "$GH_AUTH_TMP_CONFIG_DIR"
   fi
 
   log_success "Successfully authenticated gh."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -188,6 +188,20 @@ fi
 if type mise &>/dev/null; then
   log_info "Running mise bootstrap..."
 
+  # mise bootstrap installs several github: tools, each resolved through the
+  # unauthenticated GitHub API (60 requests/hour) unless gh is available and
+  # logged in. On a fresh machine gh itself is one of those tools, so install
+  # and authenticate it here first, ahead of the rest of the batch.
+  log_info "Installing and authenticating gh..."
+
+  mise install "github:cli/cli@latest"
+
+  if ! mise exec "github:cli/cli@latest" -- gh auth status &>/dev/null; then
+    mise exec "github:cli/cli@latest" -- gh auth login
+  fi
+
+  log_success "Successfully authenticated gh."
+
   # If a previous install symlinked ~/.config/mise to another checkout,
   # repoint it now: mise would otherwise keep reading (and converging to)
   # the old location's config. A real directory or file is left for the

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -197,7 +197,12 @@ if type mise &>/dev/null; then
   mise install "github:cli/cli@latest"
 
   if ! mise exec "github:cli/cli@latest" -- gh auth status &>/dev/null; then
-    mise exec "github:cli/cli@latest" -- gh auth login
+    # This login only needs to mint an API token for mise's credential_command;
+    # it runs before the dotfiles phase symlinks the real
+    # home/.config/gh/config.yml (git_protocol = ssh), so force https here to
+    # skip the SSH key detection/upload prompt, which would otherwise depend
+    # on 1Password's SSH agent already being set up.
+    mise exec "github:cli/cli@latest" -- gh auth login --git-protocol https --skip-ssh-key
   fi
 
   log_success "Successfully authenticated gh."


### PR DESCRIPTION
## Why

A fresh bootstrap failed with a GitHub API rate limit (403) while installing the `github:` tools. `gh` itself is one of them, so on a brand-new machine it was neither installed nor authenticated yet when `mise bootstrap` ran — `credential_command` had nothing to fall back on, so mise made unauthenticated requests and quickly exhausted the 60/hour limit across the batch (7 `github:` tools, some with artifact attestation verification adding extra calls each).

Separately, `credential_command` itself was broken regardless of timing: mise strips its own shims from `PATH` while running it (to avoid recursive mise invocations), and `gh` here is only ever installed as a mise shim, so the bare `gh auth token` call could never resolve it.

## What

- `scripts/install.sh`: install and authenticate `gh` first, ahead of the rest of `mise bootstrap`
- `home/.config/mise/config.toml`: fix `credential_command` to resolve gh via `$(mise which gh)` instead of the bare command, so it survives the shim-stripped `PATH` — using the dynamic form (not a hardcoded path) also keeps it working across `gh`'s "latest" upgrades

## Notes

- Verified `$(mise which gh) auth token` resolves and returns a valid token on an already-set-up machine
- In CI, `GITHUB_TOKEN` is already set as an env var, so `gh auth status` succeeds without needing `gh auth login` — the new step is a no-op there