### PR TITLE
fix(mise): pin asset and rename codex binary to fix shim resolution

### DIFF
--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -11,7 +11,6 @@ deno = "latest"
 "github:junegunn/fzf" = "latest"
 "github:microsoft/apm" = "latest"
 "github:k1LoW/git-wt" = "latest"
-"github:openai/codex" = "latest"
 "github:rossmacarthur/sheldon" = "latest"
 "github:sharkdp/fd" = "latest"
 "github:starship/starship" = "latest"
@@ -35,6 +34,17 @@ version = "latest"
 [tools."github:jqlang/jq".platforms]
 macos-x64 = { asset_pattern = "jq-macos-amd64" }
 macos-arm64 = { asset_pattern = "jq-macos-arm64" }
+
+# openai/codex ships dozens of codex-prefixed release assets (codex-app-server,
+# codex-command-runner, codex-symbols, ...), so mise's default asset-matching
+# picks the right one but keeps its OS/arch-suffixed filename as the shim name
+# (codex-aarch64-apple-darwin instead of codex). Pin the asset explicitly and
+# rename it so `codex` resolves.
+[tools."github:openai/codex"]
+version = "latest"
+
+[tools."github:openai/codex".platforms]
+macos-arm64 = { asset_pattern = "codex-aarch64-apple-darwin.zst", rename_exe = "codex" }
 
 [settings]
 experimental = true


### PR DESCRIPTION
## Why

`codex` (declared as `github:openai/codex = "latest"`) installed successfully via `mise install`, but the `codex` command never resolved — `mise which codex` reported it wasn't a mise bin.

`openai/codex`'s releases ship dozens of `codex`-prefixed assets (`codex-app-server-*`, `codex-command-runner-*`, `codex-symbols-*`, `codex-package-*`, ...) alongside the actual CLI binary. Without an explicit `asset_pattern`, mise's default matching happened to pick the right asset (`codex-aarch64-apple-darwin.zst`) but kept its OS/arch-suffixed filename as the installed binary and shim name (`codex-aarch64-apple-darwin`) instead of stripping it down to `codex`.

## What

- `home/.config/mise/config.toml`: add a `[tools."github:openai/codex".platforms]` entry pinning `asset_pattern` and `rename_exe` for `macos-arm64`, mirroring the existing `github:jqlang/jq` entry that already works around the same kind of asset ambiguity

## Notes

- Verified locally: removed the old `codex-aarch64-apple-darwin`-named install, reinstalled with this config, and `mise which codex` now resolves to a binary literally named `codex`; `codex --version` runs successfully