### PR TITLE
fix(claude): remove invalid Write deny rule for .npmrc

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -64,8 +64,7 @@
       "Edit(!.env*.example)",
       "Read(.env*)",
       "Read(!.env*.example)",
-      "Edit(~/.npmrc)",
-      "Write(~/.npmrc)"
+      "Edit(~/.npmrc)"
     ],
     "defaultMode": "auto"
   },


### PR DESCRIPTION
## Why

Claude Code warned that `Write(~/.npmrc)` in the `deny` list is never applied: file permission checks only evaluate `Edit(path)` rules. The `Write(...)` entry was dead configuration and the source of the warning.

## What

- Remove the redundant `Write(~/.npmrc)` deny rule.

`Edit(~/.npmrc)` already covers all file-editing tools (including Write), so writes to `.npmrc` remain denied.

## Notes

- `home/.claude/settings.json` is symlinked to `~/.claude/settings.json`, so no separate change is needed.
