### PR TITLE
fix(git): use git-wt default worktree basedir

### DIFF
--- a/home/.config/git/config
+++ b/home/.config/git/config
@@ -37,8 +37,5 @@
 [ghq]
   root = ~/src
 
-[wt]
-  basedir = .git/wt
-
 [include]
   path = config.local

--- a/home/.config/git/ignore
+++ b/home/.config/git/ignore
@@ -7,3 +7,4 @@ Thumbs.db
 # Others
 opensrc/
 .playwright-cli/
+.wt/


### PR DESCRIPTION
## Why

`wt.basedir` was set to `.git/wt`, placing git-wt worktrees under `.git`. vite/vitest exclude paths under `.git` from module scanning and file watching, so projects failed to run correctly inside a worktree.

## What

- Remove the `wt.basedir = .git/wt` override so git-wt falls back to its default `.wt` (repository root), keeping worktrees out of `.git`.
- Ignore `.wt/` in the global gitignore (`home/.config/git/ignore`) so worktrees nested in the working tree don't clutter `git status`.

## Notes

- Using the global gitignore (rather than each project's `.gitignore`) keeps this personal, git-wt-specific setup out of shared repositories — consistent with the existing `opensrc/` and `.playwright-cli/` entries.
- git worktree itself is unaffected by the ignore: worktree state lives in `.git/worktrees/`, while gitignore only controls what the parent repo treats as tracked.
