### PR TITLE
feat(mise): add trackpad settings to macOS defaults

### DIFF
--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -81,9 +81,11 @@ credential_command = "$HOME/.local/share/mise/installs/github-cli-cli/latest/bin
 autohide = true
 
 [bootstrap.macos.defaults]
-"NSGlobalDomain" = { AppleInterfaceStyle = "Dark", AppleShowAllExtensions = true, NSNavPanelExpandedStateForSaveMode = true }
+"NSGlobalDomain" = { AppleInterfaceStyle = "Dark", AppleShowAllExtensions = true, NSNavPanelExpandedStateForSaveMode = true, "com.apple.trackpad.scaling" = 1.5 }
 "com.apple.dock" = { wvous-tr-corner = 2, wvous-tr-modifier = 0, wvous-bl-corner = 4, wvous-bl-modifier = 0, autohide-delay = 0 }
 "com.apple.finder" = { _FXSortFoldersFirst = true, FXPreferredViewStyle = "clmv", CreateDesktop = false, NewWindowTarget = "PfHm", AppleShowAllFiles = true }
+"com.apple.AppleMultitouchTrackpad" = { Clicking = true, TrackpadThreeFingerTapGesture = 0 }
+"com.apple.driver.AppleBluetoothMultitouch.trackpad" = { Clicking = true, TrackpadThreeFingerTapGesture = 0 }
 
 [dotfiles]
 "~/.agents" = {}


### PR DESCRIPTION
## Why

The trackpad preferences that I changed from the macOS defaults were not reproduced when setting up a new machine, so they had to be re-applied by hand. Restore them declaratively via `mise bootstrap macos defaults apply`.

## What

Add trackpad settings to `[bootstrap.macos.defaults]`, limited to settings that have a corresponding control in System Settings (Trackpad).

| Domain | Key | Value | UI control |
| :-- | :-- | :-- | :-- |
| `NSGlobalDomain` | `com.apple.trackpad.scaling` | `1.5` | Tracking speed |
| `com.apple.AppleMultitouchTrackpad` / `com.apple.driver.AppleBluetoothMultitouch.trackpad` | `Clicking` | `true` | Tap to click |
| (same) | `TrackpadThreeFingerTapGesture` | `0` | Look up & data detectors (three-finger tap) |

## Notes

- The click firmness thresholds (`FirstClickThreshold` / `SecondClickThreshold`) and silent clicking (`ActuationStrength`) are intentionally left out: the current firmness values are asymmetric (`0` / `2`) and cannot be produced with the UI slider, and `ActuationStrength` has no control in the current macOS UI.
- Verified with `mise bootstrap macos defaults apply --dry-run` that all three added settings already match the current system values (reported as already set) with no type errors.
- `Clicking` is stored as int `1` on the system, but since it is an on/off toggle it is written as `-bool` (`true`) to match the existing style in this file; the behavior is identical.
