### PR TITLE
fix(dots): scope Homebrew upgrade to Brewfile in dots up

### DIFF
--- a/bin/dots
+++ b/bin/dots
@@ -14,7 +14,7 @@ dots_up() {
 
   echo "\nUpdating Homebrew..."
   brew update
-  brew upgrade
+  brew bundle install --upgrade --file="$DOTFILES_DIR/Brewfile"
 
   echo "\nUpdating mise..."
   mise self-update --yes


### PR DESCRIPTION
## Why

Plain `brew upgrade` (no args) upgrades every formula/cask currently installed on the machine, regardless of the Brewfile. #509 migrated several formulae (`git`, `vim`, `zsh`, `tailscale`, `terminal-notifier`, `dockutil`, `defaultbrowser`) to mise's `[bootstrap.packages]` and removed them from the Brewfile, but never uninstalled them from Homebrew. Since `dots up` still called bare `brew upgrade` ahead of `mise bootstrap packages upgrade`, those formulae kept getting upgraded through Homebrew — the opposite of what #509 intended (single source of truth via mise).

## What

- Replace `brew upgrade` with `brew bundle install --upgrade --file="$DOTFILES_DIR/Brewfile"` in `dots up`, matching `install.sh`'s existing use of `brew bundle`, so the Homebrew step only touches what's actually declared in the Brewfile.
- Pass `--upgrade` explicitly rather than relying on its default-on behavior, since a stray `$HOMEBREW_BUNDLE_NO_UPGRADE` in the user's shell environment would otherwise silently disable it with no error.

## Notes

Verified with `brew bundle check --file="$DOTFILES_DIR/Brewfile" --verbose` (no side effects) that the Brewfile is correctly recognized. Did not run the live upgrade command since it would replace installed cask app bundles.