### PR TITLE
feat(claude): show reasoning effort in statusline

### DIFF
--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -104,6 +104,7 @@ fi
 
 # Extract information from JSON
 model=$(echo "$input" | jq -r '.model.display_name // empty' 2>/dev/null)
+effort=$(echo "$input" | jq -r '.effort.level // empty' 2>/dev/null)
 context_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty' 2>/dev/null)
 
 # Extract usage percentages and reset times from stdin JSON
@@ -160,6 +161,9 @@ fi
 if [[ -n "$model" && "$model" != "null" ]]; then
   output+=$'\n'
   output+="Model: ${ORANGE}${model}${RESET}"
+  if [[ -n "$effort" && "$effort" != "null" ]]; then
+    output+=" (${effort})"
+  fi
 fi
 
 # Context usage


### PR DESCRIPTION
## Why

Effort level affects model behavior and cost, so it's worth surfacing at a glance alongside the model name and other statusline info (context/rate usage).

## What

Extract `.effort.level` from the statusline JSON input and append it next to the model name, e.g. `Model: Sonnet 5 (high)`. Omitted when the field is absent (models that don't support the effort parameter).

## Notes

None.