### PR TITLE
fix(starship,claude): avoid duplicate branch name in worktree prompts

### DIFF
--- a/bin/starship-dir
+++ b/bin/starship-dir
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Prints a shortened path for the starship prompt's [custom.dir] module.
+#
+# Mirrors starship's built-in directory module (fish-style prefix
+# shortening, truncated to the git repo root), but when inside a worktree
+# it keeps the path relative to the main repository instead of just the
+# repo root. This matters because tools like git-wt name worktree
+# directories after the branch, so truncating to the worktree root alone
+# would show only the branch name and duplicate the branch shown by
+# [custom.git_branch] (e.g. "branch-name on branch-name").
+
+pwd_path="$PWD"
+
+if git_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+  common_dir=$(git rev-parse --git-common-dir 2>/dev/null)
+  case "$common_dir" in
+    /*) ;;
+    *) common_dir="$git_root/$common_dir" ;;
+  esac
+  main_root=$(cd "$(dirname "$common_dir")" 2>/dev/null && pwd)
+  [ -z "$main_root" ] && main_root="$git_root"
+
+  tail="$(basename "$main_root")${git_root#"$main_root"}${pwd_path#"$git_root"}"
+  prefix="$(dirname "$main_root")"
+else
+  tail="$(basename "$pwd_path")"
+  prefix="$(dirname "$pwd_path")"
+fi
+
+case "$prefix" in
+  "$HOME") short="~" ;;
+  "$HOME"/*) short="~${prefix#"$HOME"}" ;;
+  *) short="$prefix" ;;
+esac
+
+out=""
+IFS='/' read -ra parts <<<"$short"
+for part in "${parts[@]}"; do
+  [ -z "$part" ] && continue
+  if [ "$part" = "~" ]; then
+    out+="~/"
+  elif [[ "$part" == .* ]]; then
+    out+="${part:0:2}/"
+  else
+    out+="${part:0:1}/"
+  fi
+done
+
+printf '%s%s' "$out" "$tail"

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -34,12 +34,11 @@ ICON_DRAFT=$(printf '\xEF\x93\x9D')    # nf-oct-git_pull_request_draft (U+F4DD)
 ICON_MERGED=$(printf '\xEF\x90\x99')   # nf-oct-git_merge (U+F419)
 
 # Extract current directory from JSON
-current_dir=$(echo "$input" | jq -r '.workspace.current_dir // empty' 2>/dev/null)
-if [[ -n "$current_dir" && "$current_dir" != "null" ]]; then
-  current_dir=$(basename "$current_dir")
-else
-  current_dir=$(basename "$PWD")
+raw_dir=$(echo "$input" | jq -r '.workspace.current_dir // empty' 2>/dev/null)
+if [[ -z "$raw_dir" || "$raw_dir" == "null" ]]; then
+  raw_dir="$PWD"
 fi
+current_dir=$(basename "$raw_dir")
 
 # Get Git branch and dirty state
 git_branch=""
@@ -48,6 +47,17 @@ if git rev-parse --git-dir >/dev/null 2>&1; then
   git_branch=$(git branch --show-current 2>/dev/null)
   if [[ -n "$(git status --short 2>/dev/null)" ]]; then
     git_diff="*"
+  fi
+
+  # If inside a worktree (e.g. one created by git-wt), show the main repo's
+  # name instead of the worktree directory name. Worktree directories are
+  # often named after the branch, which would otherwise duplicate the
+  # branch shown after "on" (e.g. "branch-name on branch-name").
+  git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$git_common_dir" ]]; then
+    [[ "$git_common_dir" != /* ]] && git_common_dir="$raw_dir/$git_common_dir"
+    main_root=$(cd "$(dirname "$git_common_dir")" 2>/dev/null && pwd)
+    [[ -n "$main_root" ]] && current_dir=$(basename "$main_root")
   fi
 fi
 

--- a/home/.config/starship.toml
+++ b/home/.config/starship.toml
@@ -1,6 +1,6 @@
 "$schema" = "https://starship.rs/config-schema.json"
 
-format = "$character$directory${custom.git_branch}"
+format = "$character${custom.dir}${custom.git_branch}"
 right_format = "$time"
 add_newline = false
 command_timeout = 1000
@@ -8,10 +8,10 @@ command_timeout = 1000
 [character]
 format = "[⋊>](blue) "
 
-[directory]
-truncation_length = 1
-format = "[$path](yellow) "
-fish_style_pwd_dir_length = 1
+[custom.dir]
+command = "starship-dir"
+when = "true"
+format = "[$output](yellow) "
 
 [custom.git_branch]
 command = 'out=$(git status --porcelain --branch 2>/dev/null); branch=$(printf "%s" "$out" | head -1 | sed -E "s/^## //; s/\.\.\..*//; s/ .*//"); [ "$(printf "%s\n" "$out" | wc -l)" -gt 1 ] && dirty="*" || dirty=""; printf "%s%s" "$branch" "$dirty"'


### PR DESCRIPTION
## Why

`git-wt` names worktree directories after the branch, so both the zsh
prompt (starship) and the Claude Code statusline collapsed to
"branch-name on branch-name" inside a worktree, hiding which repo it
belonged to.

## What

- `bin/starship-dir` + `starship.toml`: replace the built-in
  `[directory]` module with a custom one that keeps the path relative
  to the main repository when inside a worktree (e.g.
  `dotfiles/.wt/branch-name`), while leaving the non-worktree case
  unchanged.
- `statusline.sh`: fall back to the main repository's name instead of
  the worktree directory basename when running inside a worktree.

## Notes

Non-worktree behavior is unchanged in both cases; verified manually
against a scratch `git-wt` worktree.