### PR TITLE
feat(agents): add base branch sync step to personal-merge-pr skill

### DIFF
--- a/home/.agents/skills/personal-merge-pr/SKILL.md
+++ b/home/.agents/skills/personal-merge-pr/SKILL.md
@@ -145,3 +145,15 @@ gh repo view --json deleteBranchOnMerge -q .deleteBranchOnMerge
 ```sh
 git push origin --delete <branch-name>
 ```
+
+### ベースブランチを最新化する
+
+ブランチの削除まで終わったら、main working tree でベースブランチを最新化します。
+
+```sh
+git switch <base-branch>
+git pull
+```
+
+- main working tree の場合: `--delete-branch` によってベースブランチへ切り替わっているため、`git pull` だけで構いません
+- linked worktree の場合: `git wt -d` の前に main working tree へ移動しているため、そのまま実行できます


### PR DESCRIPTION
## Why

`personal-merge-pr` ended at branch cleanup, so the local base branch was left behind after a merge and had to be pulled by hand every time. This is easy to miss in the linked worktree case in particular: cleanup moves to the main working tree only to run `git wt -d`, so the base branch there is not even fetched.

## What

- Added a "ベースブランチを最新化する" step to `personal-merge-pr`, run after branch deletion
- Noted that the main working tree case only needs `git pull` (since `--delete-branch` already switches to the base branch), while the linked worktree case has already moved to the main working tree

## Notes

`allowed-tools` is left untouched: it currently lists read-only commands only, and `git switch` / `git pull` do not fit that policy.
