### PR TITLE
docs: disable conflicting 1Password shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ To move the checkout later, move the directory and re-run `install.sh` with
   - Default Vault
     - Save new items in: **Suggest a vault**
   - Kayboard Shortcuts
-    - Use default
+    - Show 1Password: **-**
+    - Show Quick Access: **-**
+    - Lock 1Password: **-**
+    - Autofill: **Cmd + \\**
   - Autofill
     - ✅ Submit automatically with Universal Autofill
 - Appearance


### PR DESCRIPTION
## Why

1Password's default global keyboard shortcuts collide with the Ghostty/herdr keymap.

`home/.config/ghostty/config` registers a global `alt+space` and hands the `cmd`, `cmd+alt`, `cmd+ctrl`, `cmd+shift`, and `alt` modifier families over to herdr's prefix chords, so there is essentially no room left for another app's system-wide hotkeys.

## What

Replace the "Use default" note in the 1Password settings section of `README.md` with the shortcuts actually in use:

- Show 1Password: **-**
- Show Quick Access: **-**
- Lock 1Password: **-**
- Autofill: **Cmd + \\**

Autofill is the one shortcut used day to day, and `Cmd + \` is left unbound by Ghostty, so it stays at its default.

## Notes

Documentation only; no configuration files change.
