### PR TITLE
fix(git): stop ignoring directories named opensrc

### DIFF
--- a/home/.config/git/ignore
+++ b/home/.config/git/ignore
@@ -5,6 +5,5 @@
 Thumbs.db
 
 # Others
-opensrc/
 .playwright-cli/
 .wt/


### PR DESCRIPTION
## Why

The `opensrc/` entry in the global ignore file is a leftover from when [opensrc](https://github.com/vercel-labs/opensrc) stored fetched sources in a per-project `opensrc/` folder. Since v0.7.0 it caches globally in `~/.opensrc/`, so the rule no longer matches what it was written for (and never would, since `~/.opensrc/` is dot-prefixed and lives outside any repository).

Worse, the pattern has no leading slash, so Git matches it against **any** directory named `opensrc` at any depth. That silently hid the `.agents/skills/opensrc/` skill directory from `git status` in other repositories.

## What

Remove the `opensrc/` line from `home/.config/git/ignore`.

## Notes

Verified locally with `opensrc 0.7.3`:

- Cache lives at `~/.opensrc/` (`repos/`, `sources.json`), `OPENSRC_HOME` unset
- No per-project `opensrc/` directory is created
- Upstream `CHANGELOG.md` (0.7.0): "**Global cache** — Switch from per-project `opensrc/` folder to a global `~/.opensrc/` cache, shared across all projects"

After the change, `git check-ignore -v .agents/skills/opensrc` no longer matches and the directory shows up in `git status` as expected.
