### PR TITLE
feat(hunk): wrap long diff lines by default

### DIFF
--- a/home/.config/hunk/config.toml
+++ b/home/.config/hunk/config.toml
@@ -1,1 +1,2 @@
 mode = "split"
+wrap_lines = true


### PR DESCRIPTION
## Why

Hunk truncates long diff lines by default, so the tail of a change is hidden until `--wrap` is passed on every invocation.

## What

- Set `wrap_lines = true` in `home/.config/hunk/config.toml`

## Notes

- `wrap_lines` is a documented Hunk config key (verified against the README of `npm:hunkdiff` 0.17.6)
- `~/.config/hunk/config.toml` is symlinked to this file by `mise bootstrap`, so the setting applies immediately
