### PR TITLE
feat(agents): add skill to upload attachments to GitHub

### DIFF
--- a/home/.agents/skills/personal-upload-attachment-to-github/SKILL.md
+++ b/home/.agents/skills/personal-upload-attachment-to-github/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: personal-upload-attachment-to-github
+description: ローカルのファイル（スクリーンショットや画面収録など）を GitHub にアップロードし、Issue や PR の本文に貼れる URL を取得します。ユーザーがファイルの添付や添付用 URL の取得を求めたときや、エージェントが Issue や PR にファイルを貼りたいときに使用してください。
+argument-hint: "<file-path>"
+compatibility: gh、curl、jq が必要です
+---
+
+# GitHub への添付ファイルのアップロード
+
+## 背景
+
+GitHub の Web UI でファイルをドラッグ&ドロップしたときと同じ保存先（user-attachments）へ、コマンドラインからアップロードします。
+private リポジトリでは `raw.githubusercontent.com` の URL が画像として表示できないため、Issue や PR にスクリーンショットを貼るにはこの保存先を使う必要があります。
+
+> [!NOTE]
+> 公式ドキュメントに記載のないエンドポイントを使っているため、予告なく仕様が変わる可能性があります。
+
+## 前提
+
+- 対象リポジトリへの write 権限（アップロード用のトークンは write 権限を持つユーザーにしか発行されません）
+- `gh` の認証（`repo` スコープ）
+
+## 手順
+
+### 1. アップロードする
+
+```bash
+bash ~/.agents/skills/personal-upload-attachment-to-github/scripts/upload.sh <file-path>
+```
+
+成功すると URL が出力されます。ファイルごとに 1 回ずつ実行してください。
+
+カレントディレクトリの `git remote` とは別のリポジトリを対象にする場合は、第 2 引数に repository_id を渡します。
+
+```bash
+bash ~/.agents/skills/personal-upload-attachment-to-github/scripts/upload.sh <file-path> <repository_id>
+```
+
+### 2. 本文に貼る
+
+出力された URL を、ファイルの種類に応じた記法で本文に埋め込みます。
+
+| 種類   | 記法                                                             |
+| :----- | :--------------------------------------------------------------- |
+| 画像   | `![<代替テキスト>](<url>)`                                       |
+| 動画   | URL を単体の行に置く（`![]()` で囲むと再生プレイヤーにならない） |
+| その他 | `[<ファイル名>](<url>)`                                          |
+
+## 注意点
+
+> [!IMPORTANT]
+> アップロードしたファイルを自分で削除する方法はありません（GitHub サポートへの依頼が必要です）。
+> 意図しない情報が写り込んでいないか、アップロードする前にファイルの中身を確認してください。
+
+> [!NOTE]
+> URL はリポジトリの権限を継承します。アクセス権を持つ人がブラウザでログインしているときだけ表示され、未認証では 404 になります。

--- a/home/.agents/skills/personal-upload-attachment-to-github/scripts/upload.sh
+++ b/home/.agents/skills/personal-upload-attachment-to-github/scripts/upload.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+#
+# ローカルファイルを GitHub の user-attachments にアップロードし、URL を出力する
+#
+# 【重要な制約】
+# GitHub が Web UI のために用意している、公式ドキュメントに記載のないエンドポイントを使っている。
+# 予告なく仕様が変わる可能性がある。
+# 参考: https://github.com/cli/cli/issues/13256
+#
+# 使い方: upload.sh <file-path> [repository_id]
+#
+# - repository_id を省略した場合、カレントディレクトリの git remote から解決する
+# - Content-Type は拡張子から判定し、未知の拡張子は file コマンドにフォールバックする
+# - 成功時は URL を stdout に出力し、失敗時は stderr にエラーを出して exit 1
+#
+
+set -euo pipefail
+
+file_path="${1:-}"
+repository_id="${2:-}"
+
+if [[ -z "$file_path" ]]; then
+  echo "使い方: upload.sh <file-path> [repository_id]" >&2
+  exit 1
+fi
+
+if [[ ! -f "$file_path" ]]; then
+  echo "ファイルが見つかりません: $file_path" >&2
+  exit 1
+fi
+
+token=$(gh auth token 2>/dev/null) || {
+  echo "gh auth token に失敗しました。gh auth login を実行してください" >&2
+  exit 1
+}
+
+# repository_id は数値の ID が必要（gh repo view --json id が返す node ID では通らない）
+if [[ -z "$repository_id" ]]; then
+  repository_id=$(gh api "repos/{owner}/{repo}" --jq .id 2>/dev/null) || {
+    echo "repository_id の解決に失敗しました。第 2 引数で明示してください" >&2
+    exit 1
+  }
+fi
+
+file_name=$(basename "$file_path")
+extension=$(printf '%s' "${file_name##*.}" | tr '[:upper:]' '[:lower:]')
+
+case "$extension" in
+  png) content_type="image/png" ;;
+  jpg | jpeg) content_type="image/jpeg" ;;
+  gif) content_type="image/gif" ;;
+  webp) content_type="image/webp" ;;
+  svg) content_type="image/svg+xml" ;;
+  mp4) content_type="video/mp4" ;;
+  mov) content_type="video/quicktime" ;;
+  webm) content_type="video/webm" ;;
+  *) content_type=$(file --mime-type -b "$file_path" 2>/dev/null || echo "application/octet-stream") ;;
+esac
+
+# クエリ文字列に載せるため、URL エンコードする
+# 特に content_type の "image/svg+xml" は、+ を素で渡すと空白として解釈される
+encode() {
+  jq -rn --arg value "$1" '$value | @uri'
+}
+
+response_body=$(mktemp)
+trap 'rm -f "$response_body"' EXIT
+
+query="name=$(encode "$file_name")"
+query="${query}&content_type=$(encode "$content_type")"
+query="${query}&repository_id=$(encode "$repository_id")"
+
+http_code=$(
+  curl -sS \
+    -X POST \
+    -H "Authorization: Bearer ${token}" \
+    -H "Content-Type: application/octet-stream" \
+    -H "Accept: application/json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    --data-binary "@${file_path}" \
+    -o "$response_body" \
+    -w '%{http_code}' \
+    "https://uploads.github.com/user-attachments/assets?${query}"
+)
+
+url=$(jq -r '.url // empty' <"$response_body" 2>/dev/null || true)
+
+if [[ -z "$url" ]]; then
+  echo "アップロードに失敗しました (HTTP ${http_code})" >&2
+  echo "$(<"$response_body")" >&2
+  exit 1
+fi
+
+echo "$url"


### PR DESCRIPTION
## Why

Attaching a screenshot or a screen recording to an issue or PR meant leaving the terminal for the browser. In private repositories `raw.githubusercontent.com` URLs do not render as images, so committing the file and linking to it is not a workaround — the Web UI drag-and-drop store (`user-attachments`) is the only destination that renders.

## What

Add the `personal-upload-attachment-to-github` skill:

- `SKILL.md`: when to use it, the embed syntax per file type (image / video / other), and the caveats that matter before uploading
- `scripts/upload.sh`: uploads a local file to `user-attachments` and prints the URL
  - resolves `repository_id` from the current `git remote` via `gh api repos/{owner}/{repo}` (the numeric id — the GraphQL node id is rejected), overridable by a second argument
  - derives `Content-Type` from the extension, falling back to `file --mime-type`
  - URL-encodes query values with `jq @uri`, so `image/svg+xml` is not mangled into a space

## Notes

- The endpoint is undocumented (it is what the Web UI uses, see [cli/cli#13256](https://github.com/cli/cli/issues/13256)), so it may change without notice. This is called out in both `SKILL.md` and the script header.
- Uploads cannot be deleted without contacting GitHub support, and the URLs inherit repository permissions. Both are documented as warnings in the skill.
- Requires write access to the target repository: the upload token is only issued to users who have it.
