### PR TITLE
fix(git): stop the wt hook from aborting git wt

### DIFF
--- a/home/.config/git/config
+++ b/home/.config/git/config
@@ -40,7 +40,8 @@
 [wt]
   copyignored = true
   nocopy = node_modules/
-  hook = "[ -f package.json ] && ni"
+  # Not &&: a hook that exits non-zero aborts git wt and blocks its cd.
+  hook = "! [ -f package.json ] || ni"
 
 [include]
   path = config.local


### PR DESCRIPTION
## Why

`wt.hook` ran `[ -f package.json ] && ni`, which exits non-zero in a repository that has no `package.json`.

git-wt treats a failing hook as fatal: it aborts with `Error: hook "..." failed: exit status 1`, and its shell integration then refuses to `cd` into the new worktree. Every non-Node repository hit this, so `git wt` was unusable outside of Node projects.

## What

Inverted the test so the nothing-to-install case exits zero.

```diff
-  hook = "[ -f package.json ] && ni"
+  hook = "! [ -f package.json ] || ni"
```

`ni` still runs whenever a `package.json` is present, and a genuine `ni` failure still fails the hook — worth keeping, since a worktree whose dependencies did not install is not one to `cd` into. That is also why this is not `[ -f package.json ] && ni; true`, which would swallow those failures.

The comment records why the obvious `&&` spelling is wrong, so it does not get simplified back.

## Notes

Verified against scratch repositories:

- Non-Node repository: `git wt feature-a` completes with exit 0 (previously `Error: hook ... failed: exit status 1`)
- Node repository: `ni` runs and installs as before, exit 0
