### PR TITLE
fix(zed): auto-install extension-provided themes

### DIFF
--- a/home/.config/zed/settings.json
+++ b/home/.config/zed/settings.json
@@ -9,6 +9,12 @@
   "session": {
     "trust_all_worktrees": true
   },
+  // Extensions
+  // Merged with Zed's own defaults rather than replacing them.
+  "auto_install_extensions": {
+    "one-dark-pro": true,
+    "file-icons": true
+  },
   // Appearance
   "theme": "One Dark Pro",
   "icon_theme": "File Icons",


### PR DESCRIPTION
## Why

`settings.json` selects `One Dark Pro` as the `theme` and `File Icons` as the
`icon_theme`. Neither ships with Zed — both come from extensions. On a machine
where those extensions aren't installed, Zed logs `icon theme not found: File
Icons` and silently falls back to its defaults, so the configured appearance
never takes effect.

This surfaced right after [#483](https://github.com/p-chan/dotfiles/pull/483)
landed: `mise bootstrap` installed Zed and linked `settings.json`, but nothing
installed the extensions the settings depend on, and the file icons were
missing.

## What

Declare both extensions in `auto_install_extensions` so Zed installs them on
startup.

## Notes

- Zed merges `auto_install_extensions` with its own defaults rather than
  replacing them (`MergeFrom` treats maps as a deep merge), so whatever Zed
  enables out of the box is preserved.
- Verified on a fresh install: Zed logged `installing extension file-icons
  latest version`, rebuilt its extension index, and stopped reporting the
  missing icon theme.
- `~/.config/zed/settings.json` is a symlink into this repo, and Zed's file
  watcher doesn't pick up writes to the link target. Changes to this file need
  a Zed restart to apply.