### PR TITLE
feat(zed): add Zed to the Dock

### DIFF
--- a/home/.config/mise/tasks/bootstrap
+++ b/home/.config/mise/tasks/bootstrap
@@ -38,7 +38,7 @@ if [ "${CI:-}" != "true" ]; then
   # restarting per invocation races the relaunch and spams
   # "No matching processes belonging to you were found" from killall.
   dockutil --remove all --no-restart
-  for app in Fantastical Mimestream Arc Slack Figma 1Password "Visual Studio Code" Ghostty; do
+  for app in Fantastical Mimestream Arc Slack Figma 1Password "Visual Studio Code" Zed Ghostty; do
     [ -d "/Applications/$app.app" ] && dockutil --add "/Applications/$app.app" --no-restart
   done
   killall Dock


### PR DESCRIPTION
## Why

[#483](https://github.com/p-chan/dotfiles/pull/483) made Zed part of the
environment, but the `bootstrap` task rebuilds the Dock from a fixed list of
apps that didn't include it. Zed never got a spot in the Dock.

## What

Add `Zed` to that list, next to `Visual Studio Code` — the array order is the
Dock order, so this groups the two editors together.

## Notes

- The existing `[ -d "/Applications/$app.app" ]` guard already covers machines
  where Zed isn't installed, so no extra handling is needed.
- Applied locally and verified: the Dock now reads Fantastical → Mimestream →
  Arc → Slack → Figma → 1Password → Visual Studio Code → Zed → Ghostty.