### PR TITLE
feat(zed): auto-install the TOML extension

### DIFF
--- a/home/.config/zed/settings.json
+++ b/home/.config/zed/settings.json
@@ -13,7 +13,8 @@
   // Merged with Zed's own defaults rather than replacing them.
   "auto_install_extensions": {
     "one-dark-pro": true,
-    "file-icons": true
+    "file-icons": true,
+    "toml": true
   },
   // Appearance
   "theme": "One Dark Pro",


### PR DESCRIPTION
## Why

Much of this repository's configuration is TOML — `mise/config.toml`, `starship.toml`, `sheldon/plugins.toml` — and Zed ships no built-in TOML support, so those files opened without syntax highlighting.

## What

Add `toml` to `auto_install_extensions` in `home/.config/zed/settings.json`.

## Notes

Same mechanism as [#541](https://github.com/p-chan/dotfiles/pull/541): Zed merges this map with its own defaults rather than replacing them, so nothing it enables out of the box is lost.
