### PR TITLE
feat(hunk): enable watch mode by default

### DIFF
--- a/home/.config/hunk/config.toml
+++ b/home/.config/hunk/config.toml
@@ -1,2 +1,3 @@
 mode = "split"
 wrap_lines = true
+watch = true


### PR DESCRIPTION
## Why

Reviewing agent-authored changesets often means re-reading the same diff after the agent edits more files. Without watch mode, that requires quitting and re-running `hunk diff` every time.

## What

Set `watch = true` in `home/.config/hunk/config.toml`.

## Notes

- Verified against hunkdiff 0.17.3: options resolve as CLI flag > `.hunk/config.toml` > `~/.config/hunk/config.toml`, so `--watch` still wins per invocation
- There is no `--no-watch` flag, so disabling it for a single repository means adding `watch = false` to that repository's `.hunk/config.toml`
- Watch only applies to reloadable inputs, so diffs piped through `hunk pager` from stdin (i.e. `git diff` via `core.pager`) are unaffected — it is silently ignored there rather than erroring