### PR TITLE
feat(gh): add gh-dash extension

### DIFF
--- a/gh-extensions
+++ b/gh-extensions
@@ -1,1 +1,2 @@
+dlvhdr/gh-dash
 p-chan/gh-review-comment

--- a/home/.config/gh-dash/config.yml
+++ b/home/.config/gh-dash/config.yml
@@ -1,0 +1,15 @@
+# gh-dash generates this file with its full default contents on first launch
+# when it's missing. Keeping only the settings we actually override means new
+# upstream defaults (sections, layout, theme) arrive on upgrade instead of
+# being frozen at whatever they were when this file was written.
+
+# Where to find a repo locally, so PRs can be checked out from the dashboard.
+# The `:owner/:repo` key is a catch-all template gh-dash substitutes into (see
+# GetRepoLocalPath in internal/tui/common/repopath.go) — undocumented, but the
+# only form that covers every owner at once. Wildcard keys (`owner/*`) would
+# need one entry per owner.
+#
+# The path mirrors ghq's layout under `ghq.root` (~/src, set in
+# home/.config/git/config).
+repoPaths:
+  ":owner/:repo": ~/src/github.com/:owner/:repo

--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -102,6 +102,7 @@ autohide = true
 "~/.codex/AGENTS.md" = {}
 "~/.codex/skills" = {}
 "~/.config/fixpack" = {}
+"~/.config/gh-dash/config.yml" = {}
 "~/.config/gh/config.yml" = {}
 "~/.config/ghostty" = {}
 "~/.config/herdr/config.toml" = {}


### PR DESCRIPTION
## Why

Answering "what needs my review right now" currently means running `gh pr list` once per repository. [gh-dash](https://github.com/dlvhdr/gh-dash) collapses that into a single terminal dashboard over PRs, issues, and notifications, so it is worth having on every machine rather than installed ad hoc.

## What

- Add `dlvhdr/gh-dash` to `gh-extensions`, so `mise bootstrap` installs it alongside `gh-review-comment`
- Add `home/.config/gh-dash/config.yml` carrying only `repoPaths`
- Register `~/.config/gh-dash/config.yml` in `[dotfiles]`

## Notes

### Why the config is nearly empty

gh-dash writes its full default config into `~/.config/gh-dash/config.yml` on first launch when the file is missing. Those defaults are already reasonable — PR sections for authored / review-requested / involved, matching issue sections, and a preview pane — so committing a copy of them would only freeze them at today's values and miss upstream changes on upgrade. The managed file therefore holds just the one setting gh-dash cannot infer.

### Why `repoPaths` is that setting

Checking out a PR from the dashboard needs a local path for the repository, and gh-dash has no way to guess where `ghq` put it. The config uses a `:owner/:repo` template key:

```yaml
repoPaths:
  ":owner/:repo": ~/src/github.com/:owner/:repo
```

This resolves every owner in a single entry and mirrors `ghq`'s layout under `ghq.root` (`~/src`, set in `home/.config/git/config`). The documented alternative — wildcard keys such as `p-chan/*` — matches one owner each and would need an entry per owner. The template key is undocumented but implemented in [`GetRepoLocalPath`](https://github.com/dlvhdr/gh-dash/blob/main/internal/tui/common/repopath.go) and covered by its unit tests.

### Why the file, not the directory

`~/.config/gh-dash/config.yml` is linked as a file rather than linking the whole directory, following the existing `~/.config/gh/config.yml` entry.

### Verification

- `mise dotfiles apply` creates the symlink
- `gh dash` starts and parses the config (it reaches TUI init before failing on the absent TTY in a non-interactive shell)
