### PR TITLE
feat(zed): open cli launches in new window

### DIFF
--- a/home/.config/zed/settings.json
+++ b/home/.config/zed/settings.json
@@ -6,6 +6,7 @@
   // custom settings, run `zed: open default settings` from the
   // command palette (cmd-shift-p / ctrl-shift-p)
   // General
+  "cli_default_open_behavior": "new_window",
   "session": {
     "trust_all_worktrees": true
   },


### PR DESCRIPTION
## Why

Running `zed <dir>` from another window currently reuses the existing window instead of opening a new one.

## What

Set `cli_default_open_behavior` to `new_window` in `home/.config/zed/settings.json`.

## Notes