### PR TITLE
feat(opencode): add OpenCode CLI and share global rules

### DIFF
--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -121,6 +121,7 @@ autohide = true
 "~/.config/karabiner" = {}
 "~/.config/mise" = {}
 "~/.config/opencode/AGENTS.md" = {}
+"~/.config/opencode/opencode.jsonc" = {}
 "~/.config/sheldon" = {}
 "~/.config/tmux" = {}
 "~/.config/vim" = {}

--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -49,6 +49,15 @@ version = "latest"
 [tools."github:openai/codex".platforms]
 macos-arm64 = { asset_pattern = "codex-aarch64-apple-darwin.zst", rename_exe = "codex" }
 
+# opencode's releases ship the desktop app's macOS archives alongside the CLI's
+# (opencode-desktop-mac-arm64.zip, .dmg, ...), which mise's default asset
+# matching can't tell apart. Pin the CLI archive explicitly.
+[tools."github:anomalyco/opencode"]
+version = "latest"
+
+[tools."github:anomalyco/opencode".platforms]
+macos-arm64 = { asset_pattern = "opencode-darwin-arm64.zip" }
+
 [settings]
 experimental = true
 idiomatic_version_file_enable_tools = ['node']
@@ -111,6 +120,7 @@ autohide = true
 "~/.config/git" = {}
 "~/.config/karabiner" = {}
 "~/.config/mise" = {}
+"~/.config/opencode/AGENTS.md" = {}
 "~/.config/sheldon" = {}
 "~/.config/tmux" = {}
 "~/.config/vim" = {}

--- a/home/.config/opencode/AGENTS.md
+++ b/home/.config/opencode/AGENTS.md
@@ -1,0 +1,1 @@
+../../.agents/AGENTS.md

--- a/home/.config/opencode/opencode.jsonc
+++ b/home/.config/opencode/opencode.jsonc
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "enabled_providers": ["openai"]
+}

--- a/home/.config/opencode/opencode.jsonc
+++ b/home/.config/opencode/opencode.jsonc
@@ -1,4 +1,4 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "enabled_providers": ["opencode-go", "openai"]
+  "enabled_providers": ["opencode-go", "openai"],
 }

--- a/home/.config/opencode/opencode.jsonc
+++ b/home/.config/opencode/opencode.jsonc
@@ -1,4 +1,4 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "enabled_providers": ["openai"]
+  "enabled_providers": ["opencode-go", "openai"]
 }


### PR DESCRIPTION
## Why

opencode is the third coding agent CLI kept in this repo, after Claude Code and Codex CLI. It should install with `mise bootstrap` and pick up the shared rules and skills the same way the other two do.

## What

- Add `github:anomalyco/opencode` to `[tools]`. The asset is pinned because the desktop app's macOS archives (`opencode-desktop-mac-arm64.zip`, `.dmg`, ...) ship in the same release, so mise's default asset matching cannot tell them apart from the CLI's `opencode-darwin-arm64.zip`.
- Link `~/.config/opencode/AGENTS.md` to the shared `.agents/AGENTS.md`.
- Add `~/.config/opencode/opencode.jsonc` with `enabled_providers: ["opencode-go", "openai"]`.

## Notes

Verified against opencode v1.18.10 on macOS arm64.

- **Rules**: `packages/opencode/src/session/instruction.ts` looks for `~/.config/opencode/AGENTS.md`, then `~/.claude/CLAUDE.md`, and uses the first one it finds. The fallback alone would already have worked here, since `~/.claude/CLAUDE.md` is itself a symlink to the shared file, but the explicit link keeps this independent of opencode's Claude Code compatibility behaviour.
- **Skills**: nothing to configure. `~/.agents/skills/*/SKILL.md` is one of opencode's built-in discovery paths, confirmed with `opencode debug skill`.
- **Providers**: the two subscriptions in use are opencode go (`opencode-go`) and ChatGPT Pro/Plus, which opencode exposes under the `openai` provider (`packages/opencode/src/plugin/openai/codex.ts:279`). Whitelisting them also keeps opencode zen's free models out of the picker — several of them retain prompts and use them for model improvement. The default model is left unset and picked in the TUI.
- **`opencode.jsonc` over `opencode.json`**: opencode scaffolds the `.jsonc` name itself on first run and merges both when present, so keeping a single file avoids an ambiguous global config.
- **Why link files and not the directory**: opencode also generates a `.gitignore` in `~/.config/opencode` on first run. Linking the directory would drop that into this repo.
- **Update notifications are left on**: self-update never runs under mise, because `Installation.method()` matches none of npm/yarn/pnpm/bun/brew/scoop/choco and `cli/upgrade.ts` returns early on `"unknown"`. Only the minor/major notification is left, which is a useful hint to run `dots up`.
- **Manual step** after bootstrap: `opencode auth login` (credentials live in `~/.local/share/opencode/auth.json`, outside this repo).
