### PR TITLE
feat(herdr): disable onboarding

### DIFF
--- a/home/.config/herdr/config.toml
+++ b/home/.config/herdr/config.toml
@@ -1,3 +1,5 @@
+onboarding = false
+
 [theme]
 name = "one-dark"
 


### PR DESCRIPTION
## Why
Disable herdr onboarding in the configuration.

## What
- Set `onboarding = false`.
- Add a blank line before `[theme]` for readability.

## Notes
- The functional change is disabling onboarding; the blank line is formatting only.
- TOML syntax validation passed.