### PR TITLE
feat(zsh): add fzf worktree picker on Ctrl+W

### DIFF
--- a/home/.config/zsh/.zshrc
+++ b/home/.config/zsh/.zshrc
@@ -122,6 +122,53 @@ function _gh_pr_fuzzy_worktree() {
 zle -N _gh_pr_fuzzy_worktree
 bindkey "^P" _gh_pr_fuzzy_worktree
 
+# 現在のリポジトリの worktree 一覧から選んで移動する
+function _git_worktree_fuzzy_cd() {
+  local worktrees=$(command git worktree list --porcelain 2>/dev/null)
+  if [[ -z "$worktrees" ]]; then
+    zle -M "Not a git repository"
+    return
+  fi
+
+  local cwd=$(command git rev-parse --show-toplevel)
+
+  local selected=$(
+    print -r -- "$worktrees" | awk -v cwd="$cwd" '
+      function flush() {
+        if (path == "") return
+        n++
+        paths[n] = path
+        # detached HEAD の worktree には branch 行がない
+        refs[n] = (ref == "" ? "(detached)" : ref)
+        marks[n] = (path == cwd ? "*" : " ")
+        if (length(refs[n]) > width) width = length(refs[n])
+        path = ""; ref = ""
+      }
+      /^worktree / { flush(); path = substr($0, 10) }
+      /^branch /   { ref = substr($0, 8); sub(/^refs\/heads\//, "", ref) }
+      END {
+        flush()
+        for (i = 1; i <= n; i++)
+          printf "%s \033[32m%-*s\033[0m\t%s\n", marks[i], width, refs[i], paths[i]
+      }
+    ' | fzf --ansi --delimiter=$'\t' --with-nth=1 --preview '
+      echo {2}
+      echo
+      git -C {2} -c color.ui=always status --short --branch
+      echo
+      git -C {2} log --oneline --decorate --color=always -20
+    '
+  )
+
+  if [[ -n "$selected" ]]; then
+    BUFFER="cd ${(q)${selected##*$'\t'}}"
+    zle accept-line
+  fi
+}
+
+zle -N _git_worktree_fuzzy_cd
+bindkey "^W" _git_worktree_fuzzy_cd
+
 function _ghq_fuzzy_cd() {
   local root=$(ghq root)
   local selected=$(ghq list | fzf --preview "


### PR DESCRIPTION
## Why

Moving between worktrees meant typing out the full path or recalling the branch name first. The repository already has fzf pickers for the two other things worth jumping to — pull requests on <kbd>Ctrl</kbd> + <kbd>P</kbd> and ghq repositories on <kbd>Ctrl</kbd> + <kbd>G</kbd> — so worktrees were the remaining gap.

## What

Add `_git_worktree_fuzzy_cd` to `home/.config/zsh/.zshrc` and bind it to <kbd>Ctrl</kbd> + <kbd>W</kbd>. It parses `git worktree list --porcelain`, lets you pick a worktree with fzf, and then `cd`s to it via `BUFFER` + `zle accept-line`, the same way the existing pickers work.

- The list shows branch names only, with `*` marking the worktree the shell is currently in. Paths are kept in a hidden tab-separated field, since they are mostly `.wt/<branch>` and would just repeat the first column.
- The preview shows the worktree's path, `git status --short --branch`, and the last 20 commits.
- A worktree in detached HEAD state has no `branch` line in the porcelain output, so it is shown as `(detached)`.
- Outside a Git repository the function prints `Not a git repository` with `zle -M` and leaves the buffer alone.

## Notes

This overrides `vi-backward-kill-word`, so deleting the previous word at the prompt is no longer bound to <kbd>Ctrl</kbd> + <kbd>W</kbd>. Inside fzf's own prompt <kbd>Ctrl</kbd> + <kbd>W</kbd> still deletes a word, because fzf handles that key itself. If a replacement is wanted at the zsh prompt, `bindkey '^[^?' backward-kill-word` puts it on <kbd>Alt</kbd> + <kbd>Backspace</kbd>.

Verified by sourcing `.zshrc` in a non-interactive zsh with `fzf` and `zle` stubbed out:

- In a repository with five worktrees, selecting one builds `cd <path of the selected worktree>`.
- In `$HOME`, the function emits the `Not a git repository` message and nothing else.
- `bindkey "^W"` reports `_git_worktree_fuzzy_cd`.
