### PR TITLE
feat(git): ignore Playwright MCP output directory

### DIFF
--- a/home/.config/git/ignore
+++ b/home/.config/git/ignore
@@ -6,4 +6,5 @@ Thumbs.db
 
 # Others
 .playwright-cli/
+.playwright-mcp/
 .wt/


### PR DESCRIPTION
## Why

Playwright MCP writes page snapshots, console logs, and network logs into `.playwright-mcp/` in the current working directory whenever `--output-dir` (or `PLAYWRIGHT_MCP_OUTPUT_DIR`) is unset, so any repository where an agent drives a browser ends up with an untracked directory in `git status`.

The sibling directory `.playwright-cli/` was already ignored globally. Both names come from the same code path in `@playwright/mcp` — it only picks `.playwright-cli` in skill mode, and `.playwright-mcp` otherwise — so ignoring just one of them left the MCP case uncovered.

## What

Add `.playwright-mcp/` to the machine-wide gitignore (`home/.config/git/ignore`), next to the existing `.playwright-cli/` entry.

## Notes

The directory name was verified against `@playwright/mcp@0.0.78`, where `outputDir()` resolves to `path.join(cwd, config.skillMode ? '.playwright-cli' : '.playwright-mcp')` when no output directory is configured.

Keeping this in the global ignore rather than per-project `.gitignore` files matches how `.playwright-cli/` and `.wt/` are already handled: these are artifacts of my local tooling, not of any particular repository.
