### PR TITLE
style(zsh): remove trailing blank line

### DIFF
--- a/home/.config/zsh/.zshrc
+++ b/home/.config/zsh/.zshrc
@@ -195,4 +195,3 @@ bindkey "^G" _ghq_fuzzy_cd
 if [[ -f "${ZDOTDIR:-$HOME}/.zshrc.local" ]]; then
   source "${ZDOTDIR:-$HOME}/.zshrc.local"
 fi
-


### PR DESCRIPTION
## Why

Keep `.zshrc` ending consistently without a redundant blank line.

## What

- Remove the extra blank line after the final `fi`.

## Notes

- This does not change shell behavior.
- Verified with `zsh -n home/.config/zsh/.zshrc`.