### PR TITLE
style(claude): sort enabled plugins

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -126,8 +126,8 @@
     "command": "bash ~/.claude/statusline.sh"
   },
   "enabledPlugins": {
-    "example-skills@anthropic-agent-skills": true,
-    "codex@openai-codex": true
+    "codex@openai-codex": true,
+    "example-skills@anthropic-agent-skills": true
   },
   "extraKnownMarketplaces": {
     "openai-codex": {


### PR DESCRIPTION
## Why

Keep Claude Code plugin settings in a consistent, predictable order.

## What

- Sort `enabledPlugins` keys alphabetically.

## Notes

- This does not change which plugins are enabled.
- Validated the staged JSON with `jq`.