### PR TITLE
style(claude): sort setting flags

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -141,6 +141,6 @@
   "alwaysThinkingEnabled": true,
   "autoMemoryEnabled": false,
   "theme": "dark",
-  "voiceEnabled": true,
-  "skipAutoPermissionPrompt": true
+  "skipAutoPermissionPrompt": true,
+  "voiceEnabled": true
 }


### PR DESCRIPTION
## Why

Keep adjacent Claude Code boolean settings in a consistent alphabetical order.

## What

- Place `skipAutoPermissionPrompt` before `voiceEnabled`.

## Notes

- This does not change either setting value.
- Validated the staged JSON with `jq`.