### PR TITLE
feat(claude): use Opus as default model

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -68,6 +68,7 @@
     ],
     "defaultMode": "auto"
   },
+  "model": "opus",
   "hooks": {
     "PermissionRequest": [
       {


### PR DESCRIPTION
## Why

Use Opus by default for Claude sessions.

## What

- Set `model` to `opus` in the Claude settings.

## Notes

- Validated the settings with `jq empty home/.claude/settings.json`.