### PR TITLE
feat(claude): enable remote control at startup

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -142,6 +142,7 @@
   "alwaysThinkingEnabled": true,
   "autoMemoryEnabled": false,
   "theme": "dark",
+  "remoteControlAtStartup": true,
   "skipAutoPermissionPrompt": true,
   "voiceEnabled": true
 }


### PR DESCRIPTION
## Why

Make Claude Remote Control available automatically when a session starts.

## What

- Enable `remoteControlAtStartup` in the Claude settings.

## Notes

- Validated the settings with `jq empty home/.claude/settings.json`.