### PR TITLE
feat(claude): enable agent push notifications

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -143,6 +143,7 @@
   "autoMemoryEnabled": false,
   "theme": "dark",
   "remoteControlAtStartup": true,
+  "agentPushNotifEnabled": true,
   "skipAutoPermissionPrompt": true,
   "voiceEnabled": true
 }


### PR DESCRIPTION
## Why

Receive push notifications for Claude agent activity.

## What

- Enable `agentPushNotifEnabled` in the Claude settings.

## Notes

- Validated the settings with `jq empty home/.claude/settings.json`.