### PR TITLE
chore(homebrew): commonize ChatGPT and Claude casks

### DIFF
--- a/home/.config/homebrew/Brewfile
+++ b/home/.config/homebrew/Brewfile
@@ -3,4 +3,6 @@
 # dependency on machines where Homebrew already provides that file.
 brew "eza"
 cask "1password-cli"
+cask "chatgpt"
+cask "claude"
 cask "gcloud-cli"

--- a/home/.config/homebrew/profiles/Brewfile.desktop
+++ b/home/.config/homebrew/profiles/Brewfile.desktop
@@ -3,9 +3,7 @@
 tap "steipete/tap", trusted: { cask: "codexbar" }
 cask "1password"
 cask "arc"
-cask "claude"
 cask "cleanshot"
-cask "chatgpt"
 cask "codexbar"
 cask "cyberduck"
 cask "docker-desktop"


### PR DESCRIPTION
## Why

ChatGPT Remote Control and Claude Desktop Dispatch should be available on both desktop and server machines.

## What

Move the `chatgpt` and `claude` casks from the desktop profile Brewfile to the common Brewfile.

## Notes

Verified both Brewfiles with `brew bundle list --all`.