### PR TITLE
docs: add Chrome setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Configure applications that require manual setup:
 
 - [1Password](docs/apps/1password.md)
 - [Arc](docs/apps/arc.md)
+- [Chrome](docs/apps/chrome.md)
 - [Fantastical](docs/apps/fantastical.md)
 - [Logi Options+](docs/apps/logi-options-plus.md)
 - [iStat Menus](docs/apps/istat-menus.md)

--- a/docs/apps/chrome.md
+++ b/docs/apps/chrome.md
@@ -1,0 +1,5 @@
+# Chrome
+
+- Open [Gemini in Chrome](chrome://settings/ai/gemini)
+- Under Preferences, disable **Show Gemini in Chrome in Mac menu bar and turn on keyboard shortcut**
+- Clear **Navigation shortcut** to set it to **Not set**


### PR DESCRIPTION
## Why

Chrome requires a few manual Gemini settings after installation.

## What

- Add Chrome setup instructions for Gemini preferences.
- Link Chrome from the manual application setup list.

## Notes

- The menu bar setting hides the Keyboard shortcut setting when disabled, so only the Navigation shortcut is cleared.