### PR TITLE
chore(ghostty): launch herdr without a session name

### DIFF
--- a/home/.config/ghostty/config
+++ b/home/.config/ghostty/config
@@ -8,7 +8,7 @@ theme = one-dark-pro
 cursor-style = block
 background-opacity = 0.75
 background-opacity-cells = true
-command = zsh -l -i -c "herdr --session main"
+command = zsh -l -i -c "herdr"
 maximize = true
 keybind = global:alt+space=toggle_visibility
 keybind = cmd+r=text:\x0c


### PR DESCRIPTION
## Why

`--session main` was carried over from the previous `tmux new-session -A -s main`, where a name was required for attach-or-create. Bare `herdr` already launches or attaches to its persistent session, so the explicit name bought nothing and split the setup in two: Ghostty opened the `main` session while any hand-typed `herdr` went to herdr's default session, leaving an unattached server running in the background. The name `main` also reads as a Git branch, which is confusing next to herdr's worktree features.

## What

- Drop `--session main` from the Ghostty startup command so herdr uses its default persistent session.

## Notes

- The old `main` session was stopped and deleted locally (`herdr session stop main` / `herdr session delete main`); its tabs and panes are not carried over to the default session.
