### PR TITLE
feat: add mosh

### DIFF
--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -84,6 +84,7 @@ pre-packages = 'if command -v brew >/dev/null 2>&1; then brew bundle --file="$(m
 
 [bootstrap.packages]
 "brew:git" = "latest"
+"brew:mosh" = "latest"
 "brew:tailscale" = "latest"
 "brew:vim" = "latest"
 "brew:zsh" = "latest"


### PR DESCRIPTION
## Why

Plain SSH drops sessions when the network changes or the machine sleeps. mosh survives both, which matters most when connecting from a phone over Tailscale.

## What

Add `brew:mosh` to `[bootstrap.packages]`. The formula ships both the client and `mosh-server`, so one common entry covers connecting from and to any machine — no need to split it across the desktop and server profiles.

## Notes

mise can't manage mosh directly: its GitHub Releases ship only a source tarball and a macOS `.pkg` (so the `github:` backend finds no binary), and aqua-registry has no package for it.

Connecting from iOS over Tailscale SSH is already working, but it does not exercise this formula — the client transfers its own `mosh-server` build and runs it by absolute path. This entry is what Mac-to-Mac `mosh` will use, which has not been tried yet.