### PR TITLE
fix(mise): install codex from the package archive

### DIFF
--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -39,14 +39,15 @@ macos-arm64 = { asset_pattern = "jq-macos-arm64" }
 
 # openai/codex ships dozens of codex-prefixed release assets (codex-app-server,
 # codex-command-runner, codex-symbols, ...), so mise's default asset-matching
-# picks the right one but keeps its OS/arch-suffixed filename as the shim name
-# (codex-aarch64-apple-darwin instead of codex). Pin the asset explicitly and
-# rename it so `codex` resolves.
+# can't tell them apart. The plain codex-*.zst also holds the main binary alone,
+# while code mode needs codex to spawn a separate codex-code-mode-host. Pin the
+# package archive instead: it bundles both under bin/ (plus the rg and zsh
+# resources codex expects), so a single version keeps them in sync.
 [tools."github:openai/codex"]
 version = "latest"
 
 [tools."github:openai/codex".platforms]
-macos-arm64 = { asset_pattern = "codex-aarch64-apple-darwin.zst", rename_exe = "codex" }
+macos-arm64 = { asset_pattern = "codex-package-aarch64-apple-darwin.tar.zst", bin_path = "bin" }
 
 # opencode's releases ship the desktop app's macOS archives alongside the CLI's
 # (opencode-desktop-mac-arm64.zip, .dmg, ...), which mise's default asset


### PR DESCRIPTION
## Why

Running Codex code mode failed with `failed to spawn code-mode host ... code-mode-host: No such file or directory`. Code mode needs `codex` to spawn a separate `codex-code-mode-host` binary, but the `codex-aarch64-apple-darwin.zst` asset we pinned in [#523](https://github.com/p-chan/dotfiles/pull/523) contains only the main binary, so the host was never installed.

## What

Switch the asset to `codex-package-aarch64-apple-darwin.tar.zst` and point mise at its `bin` directory. The archive bundles `codex` and `codex-code-mode-host` together, plus the `rg` and `zsh` resources `codex` expects, so both binaries land on `PATH` from a single tool definition. `rename_exe` is no longer needed because the binaries already have their final names inside the archive.

## Notes

The alternative was registering the two assets as separate tools via `[tool_alias]`, but mise's docs warn that aliases are for independent binaries, not assets that must compose together — and two `latest` entries could resolve to different versions. Sharing one tool definition makes that drift impossible and downloads 77MB once instead of two ~220MB binaries.

Verified on macOS arm64 after `mise uninstall` + `mise install` + `mise reshim`:

- `~/.local/share/mise/installs/github-openai-codex/rust-v0.147.0/bin/` contains both `codex` and `codex-code-mode-host`
- shims exist for both, and `codex --version` reports `codex-cli 0.147.0`

Separately, a stale global `@openai/codex@0.142.5` from npm was shadowing the mise shim under Node.js 24.12.0 — exactly the per-project version drift that motivated managing `codex` with mise in the first place. It has been uninstalled locally; no repository change was needed.