### PR TITLE
feat(claude): add zed command

### DIFF
--- a/home/.claude/commands/zed.md
+++ b/home/.claude/commands/zed.md
@@ -1,0 +1,11 @@
+---
+allowed-tools: Bash(zed:*), Bash(git rev-parse:*)
+description: 現在のワークツリーのルートを Zed で開く
+---
+
+1. `git rev-parse --show-toplevel` でワークツリーのルートを取得します
+2. `zed <ワークツリーのルート>` を実行します
+
+Git リポジトリの外にいる場合は `zed .` を実行します。
+
+実行後の報告は不要です。

--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -95,6 +95,7 @@ pre-packages = 'if command -v brew >/dev/null 2>&1; then brew bundle --file="$(m
 "~/.apm/apm.lock.yaml" = {}
 "~/.apm/apm.yml" = {}
 "~/.claude/CLAUDE.md" = {}
+"~/.claude/commands" = {}
 "~/.claude/hooks" = {}
 "~/.claude/rules" = {}
 "~/.claude/settings.json" = {}


### PR DESCRIPTION
## Why

Moving from Claude Code to the editor meant copying the repository path by hand. A `/zed` command removes that step.

## What

Add `home/.claude/commands/zed.md`, a Claude Code custom command that opens the current worktree in Zed, and register `~/.claude/commands` under `[dotfiles]` so `mise bootstrap` symlinks the directory.

The command resolves the root with `git rev-parse --show-toplevel` instead of running `zed .`. Claude Code can start in a subdirectory, and `zed .` would open only that subdirectory, hiding the rest of the repository. Outside a Git repository it falls back to `zed .`.

## Notes

`allowed-tools` is limited to `Bash(zed:*)` and `Bash(git rev-parse:*)`, so the command runs without a permission prompt.

`~/.claude/commands` is the first entry of its kind, so the symlink was created by hand on this machine; `mise bootstrap` covers it from now on.