### PR TITLE
ci: relax npm trust policy check on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           NONINTERACTIVE=1 \
           HOMEBREW_BUNDLE_CASK_SKIP="${{ needs.get-cask-packages.outputs.packages }}" \
           MISE_GPG_VERIFY=false \
+          AUBE_TRUST_POLICY=off \
           bash scripts/install.sh
       - name: Doctor
         run: zsh scripts/doctor.sh


### PR DESCRIPTION
## Why

Some legitimate maintainers publish npm packages manually without provenance attestation, which trips aube's trust-policy no-downgrade check (e.g. hunkdiff's `@pierre/theme` dependency going from a provenance-attested release to one without it). Excluding individual packages via `trust_policy_excludes` would need ongoing upkeep as this happens again for other packages.

## What

Add `AUBE_TRUST_POLICY=off` to the CI `install` step, mirroring the existing `MISE_GPG_VERIFY=false` pattern. This relaxes the check in CI only; local development is unaffected since no `aube-workspace.yaml` is committed to the repo.

## Notes

None.