### PR TITLE
feat(macos): disable the fn key input source switch

### DIFF
--- a/home/.config/mise/tasks/bootstrap-desktop
+++ b/home/.config/mise/tasks/bootstrap-desktop
@@ -16,6 +16,7 @@ export DOTFILES_DIR
 
 if [ "${CI:-}" != "true" ]; then
   defaults write NSGlobalDomain AppleLanguages -array "en" "ja"
+  defaults write com.apple.HIToolbox AppleFnUsageType -int 0
   defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 60 "<dict><key>enabled</key><false/></dict>"
   defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 64 "<dict><key>enabled</key><false/></dict>"
 


### PR DESCRIPTION
## Why

The globe/fn key changes the input source by default, so it fires alongside apps that bind the fn key as a global shortcut. Input source switching is already covered by the Karabiner rule on the left and right command keys, so the standalone fn action is redundant.

## What

- Set `AppleFnUsageType` to `0` (Do Nothing) in the desktop bootstrap task

## Notes

The value lives in `com.apple.HIToolbox`, not `NSGlobalDomain`. Writing it to `NSGlobalDomain` has no effect, and either way it applies after logging back in.