### PR TITLE
docs: add Handy setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Configure applications that require manual setup:
 - [Arc](docs/apps/arc.md)
 - [Chrome](docs/apps/chrome.md)
 - [Fantastical](docs/apps/fantastical.md)
+- [Handy](docs/apps/handy.md)
 - [Logi Options+](docs/apps/logi-options-plus.md)
 - [iStat Menus](docs/apps/istat-menus.md)
 - [Slack](docs/apps/slack.md)

--- a/docs/apps/handy.md
+++ b/docs/apps/handy.md
@@ -1,0 +1,45 @@
+# Handy
+
+## Settings
+
+- General
+  - General
+    - Transcribe Shortcut: **fn**
+    - ☐ Push To Talk
+    - Cancel Shortcut: **Escape**
+  - Nemotron Streaming 3.5 Settings
+    - Language: **Japanese**
+  - Sound
+    - Microphone: **Default**
+    - ☐ Mute While Recording
+    - ✅ Audio Feedback
+    - Output Device: **Default**
+    - Volume: **50%**
+- Models
+  - Downloaded Models
+    - **Nemotron Streaming 3.5**
+- Advanced
+  - App
+    - ☐ Start Hidden
+    - ✅ Launch on Startup
+    - ✅ Show Tray Icon
+    - Overlay: **Live**
+    - Overlay Position: **Bottom**
+    - Unload Model: **After 5 minutes**
+    - ☐ Experimental Features
+  - Output
+    - Paste Method: **Clipboard (Cmd+V)**
+    - Clipboard Handling: **Don't Modify Clipboard**
+    - Auto Submit: **Off**
+  - Transcription
+    - ✅ Voice Activity Detection
+    - Custom Words: **-**
+    - ✅ Append Trailing Space
+  - History
+    - History Limit: **9999 entries**
+    - Auto-Delete Recordings: **After 3 days**
+- About
+  - About
+    - Application Language: **English**
+    - Application Theme: **System**
+    - ✅ Show What's New


### PR DESCRIPTION
## Why

Handy is installed as a cask, but everything else about it is configured in the app itself, so `mise bootstrap` cannot reproduce it. Recording the settings keeps them reproducible on a new machine, the same way as the other apps that need manual setup.

## What

- Add `docs/apps/handy.md` with the full settings of the Handy app
- Link it from the Setup section in `README.md`

## Notes

The document lists every setting visible in the app, not only the ones that differ from the defaults, so it stays unambiguous when upstream defaults change. Sections that are currently hidden are left out: Post Process and Debug appear only once their toggles are on, the Experimental group only with experimental features enabled, Typing Tool only on Linux, and Translate to English only for models that support it.