### PR TITLE
docs: list all GUI apps in a setup table

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,16 +71,39 @@ macOS settings automatically.
 
 ## Setup
 
-Configure applications that require manual setup:
+GUI applications installed by Homebrew. **Dotfiles** is the config path
+this repo symlinks into place, and **Document** links to the steps to
+follow by hand after install.
 
-- [1Password](docs/apps/1password.md)
-- [Arc](docs/apps/arc.md)
-- [Chrome](docs/apps/chrome.md)
-- [Fantastical](docs/apps/fantastical.md)
-- [Handy](docs/apps/handy.md)
-- [Logi Options+](docs/apps/logi-options-plus.md)
-- [iStat Menus](docs/apps/istat-menus.md)
-- [Slack](docs/apps/slack.md)
+| App                 | Start at login | Dotfiles                      | Document                                                         |
+| :------------------ | :------------- | :---------------------------- | :--------------------------------------------------------------- |
+| 1Password           | ✅             | —                             | [docs/apps/1password.md](docs/apps/1password.md)                 |
+| Arc                 | ☐              | —                             | [docs/apps/arc.md](docs/apps/arc.md)                             |
+| ChatGPT             | ☐              | —                             | —                                                                |
+| Claude              | ☐              | —                             | —                                                                |
+| CleanShot X         | ✅             | —                             | —                                                                |
+| CodexBar            | ✅             | —                             | —                                                                |
+| Cyberduck           | ☐              | —                             | —                                                                |
+| Docker Desktop      | ✅             | —                             | —                                                                |
+| Fantastical         | ✅             | —                             | [docs/apps/fantastical.md](docs/apps/fantastical.md)             |
+| Figma               | ☐              | —                             | —                                                                |
+| Ghostty             | ☐              | `~/.config/ghostty`           | —                                                                |
+| Google Chrome       | ☐              | —                             | [docs/apps/chrome.md](docs/apps/chrome.md)                       |
+| Google Japanese IME | ☐              | —                             | —                                                                |
+| Handy               | ✅             | —                             | [docs/apps/handy.md](docs/apps/handy.md)                         |
+| iStat Menus         | ✅             | —                             | [docs/apps/istat-menus.md](docs/apps/istat-menus.md)             |
+| Karabiner-Elements  | ✅             | `~/.config/karabiner`         | —                                                                |
+| Logi Options+       | ✅             | —                             | [docs/apps/logi-options-plus.md](docs/apps/logi-options-plus.md) |
+| Mimestream          | ☐              | —                             | —                                                                |
+| Raycast             | ✅             | —                             | —                                                                |
+| Slack               | ✅             | —                             | [docs/apps/slack.md](docs/apps/slack.md)                         |
+| Zed                 | ☐              | `~/.config/zed/settings.json` | —                                                                |
+
+A fresh machine only needs a handful of these before it is workable:
+1Password for the credentials and license keys the other documents link
+to, Arc as the main browser to sign in everywhere else, Karabiner-Elements,
+Google Japanese IME, and Logi Options+ for keyboard and mouse input, and
+Raycast as the launcher. The rest can wait until they are actually needed.
 
 ## Maintenance
 


### PR DESCRIPTION
## Why

The Setup section only linked the apps that need manual steps, so there was no single place showing which GUI apps get installed or how each one is configured. Whether an app is covered by a symlinked config, a manual document, or neither was only discoverable by reading `mise/config.toml` and `docs/apps/`.

## What

- Replace the link list in the Setup section with a table covering every GUI cask in `Brewfile` and `Brewfile.desktop`
- Record for each app whether it starts at login, the config path this repo symlinks (`Dotfiles`), and the setup document to follow by hand (`Document`)
- Add a paragraph below the table naming the apps a fresh machine needs first, and why

## Notes

Fonts and CLI-only casks (`1password-cli`, `gcloud-cli`) are left out, so the table lists 21 apps.

The `Start at login` column is not managed by this repo, so it can drift from the real settings. Only 1Password and Handy have the value written down in their documents; the rest were filled in from how each app is normally used and are worth checking against a real machine.

Two rows do not mean quite the same thing as the others: Google Japanese IME is an input source rather than a login item, and Karabiner-Elements runs as a background service instead of a user-configured login item.