### PR TITLE
chore(git): ignore `mise.local.toml`

### DIFF
--- a/home/.config/git/ignore
+++ b/home/.config/git/ignore
@@ -8,3 +8,4 @@ Thumbs.db
 .playwright-cli/
 .playwright-mcp/
 .wt/
+mise.local.toml


### PR DESCRIPTION
## Why

`mise.local.toml` holds machine-local task and env overrides. It is meant to stay on a single machine and should never be committed to any repository.

## What

Add `mise.local.toml` to the global gitignore (`home/.config/git/ignore`).

## Notes

`mise.toml` and `.mise.toml` are still tracked as usual, so only the local override file is ignored.