### PR TITLE
docs: add Google Japanese IME setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,29 +75,29 @@ GUI applications installed by Homebrew. **Dotfiles** is the config path
 this repo symlinks into place, and **Document** links to the steps to
 follow by hand after install.
 
-| App                 | Start at login | Dotfiles                      | Document                                                         |
-| :------------------ | :------------- | :---------------------------- | :--------------------------------------------------------------- |
-| 1Password           | ✅             | —                             | [docs/apps/1password.md](docs/apps/1password.md)                 |
-| Arc                 | ☐              | —                             | [docs/apps/arc.md](docs/apps/arc.md)                             |
-| ChatGPT             | ☐              | —                             | —                                                                |
-| Claude              | ☐              | —                             | —                                                                |
-| CleanShot X         | ✅             | —                             | —                                                                |
-| CodexBar            | ✅             | —                             | —                                                                |
-| Cyberduck           | ☐              | —                             | —                                                                |
-| Docker Desktop      | ✅             | —                             | —                                                                |
-| Fantastical         | ✅             | —                             | [docs/apps/fantastical.md](docs/apps/fantastical.md)             |
-| Figma               | ☐              | —                             | —                                                                |
-| Ghostty             | ☐              | `~/.config/ghostty`           | —                                                                |
-| Google Chrome       | ☐              | —                             | [docs/apps/chrome.md](docs/apps/chrome.md)                       |
-| Google Japanese IME | ☐              | —                             | —                                                                |
-| Handy               | ✅             | —                             | [docs/apps/handy.md](docs/apps/handy.md)                         |
-| iStat Menus         | ✅             | —                             | [docs/apps/istat-menus.md](docs/apps/istat-menus.md)             |
-| Karabiner-Elements  | ✅             | `~/.config/karabiner`         | —                                                                |
-| Logi Options+       | ✅             | —                             | [docs/apps/logi-options-plus.md](docs/apps/logi-options-plus.md) |
-| Mimestream          | ☐              | —                             | —                                                                |
-| Raycast             | ✅             | —                             | —                                                                |
-| Slack               | ✅             | —                             | [docs/apps/slack.md](docs/apps/slack.md)                         |
-| Zed                 | ☐              | `~/.config/zed/settings.json` | —                                                                |
+| App                 | Start at login | Dotfiles                      | Document                                                             |
+| :------------------ | :------------- | :---------------------------- | :------------------------------------------------------------------- |
+| 1Password           | ✅             | —                             | [docs/apps/1password.md](docs/apps/1password.md)                     |
+| Arc                 | ☐              | —                             | [docs/apps/arc.md](docs/apps/arc.md)                                 |
+| ChatGPT             | ☐              | —                             | —                                                                    |
+| Claude              | ☐              | —                             | —                                                                    |
+| CleanShot X         | ✅             | —                             | —                                                                    |
+| CodexBar            | ✅             | —                             | —                                                                    |
+| Cyberduck           | ☐              | —                             | —                                                                    |
+| Docker Desktop      | ✅             | —                             | —                                                                    |
+| Fantastical         | ✅             | —                             | [docs/apps/fantastical.md](docs/apps/fantastical.md)                 |
+| Figma               | ☐              | —                             | —                                                                    |
+| Ghostty             | ☐              | `~/.config/ghostty`           | —                                                                    |
+| Google Chrome       | ☐              | —                             | [docs/apps/chrome.md](docs/apps/chrome.md)                           |
+| Google Japanese IME | ☐              | —                             | [docs/apps/google-japanese-ime.md](docs/apps/google-japanese-ime.md) |
+| Handy               | ✅             | —                             | [docs/apps/handy.md](docs/apps/handy.md)                             |
+| iStat Menus         | ✅             | —                             | [docs/apps/istat-menus.md](docs/apps/istat-menus.md)                 |
+| Karabiner-Elements  | ✅             | `~/.config/karabiner`         | —                                                                    |
+| Logi Options+       | ✅             | —                             | [docs/apps/logi-options-plus.md](docs/apps/logi-options-plus.md)     |
+| Mimestream          | ☐              | —                             | —                                                                    |
+| Raycast             | ✅             | —                             | —                                                                    |
+| Slack               | ✅             | —                             | [docs/apps/slack.md](docs/apps/slack.md)                             |
+| Zed                 | ☐              | `~/.config/zed/settings.json` | —                                                                    |
 
 A fresh machine only needs a handful of these before it is workable:
 1Password for the credentials and license keys the other documents link

--- a/docs/apps/google-japanese-ime.md
+++ b/docs/apps/google-japanese-ime.md
@@ -1,0 +1,8 @@
+# Google Japanese IME
+
+- Open **System Settings > Keyboard > Text Input > Input Sources > Edit**
+- Press **+** and add **Japanese > Hiragana (Google)**
+- Press **+** and add **Japanese > Alphanumeric (Google)**
+- Select **Japanese - Romaji** and check **Romaji** under Input modes
+- Select **ABC** and press **−**
+- Select **Japanese - Romaji** and press **−**


### PR DESCRIPTION
## Why

Google Japanese IME was the only app in the Setup table with neither a dotfiles path nor a setup document, and it turned out to need the most delicate manual work of any of them.

Its input sources cannot be configured by `mise bootstrap` at all. TIS, the API behind input source changes, accepts a third-party input method and reports success, but nothing reaches `com.apple.inputsources` and the next process sees the source unchanged.

## What

Record the steps in `docs/apps/google-japanese-ime.md` and link it from the Setup table.

The steps are listed in the order they have to run. Checking **Romaji** on **Japanese - Romaji** looks redundant, but macOS keeps one ASCII-capable input source of its own enabled and refuses to remove the last one, and **Alphanumeric (Google)** cannot take that slot. Without that step the **−** button for **ABC** stays disabled.

## Notes

Automating the removal of **ABC** and **Japanese - Romaji** was prototyped and dropped. The step that matters most has to be manual anyway, so the setup document is needed either way, and the automation would have encoded three undocumented macOS rules discovered by trial and error — rules System Settings already handles on its own.

The end state has been verified on this machine: the input source list holds only **Hiragana (Google)** and **Alphanumeric (Google)**.