### PR TITLE
docs: add Figma setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ follow by hand after install.
 | Cyberduck           | ☐              | —                             | —                                                                    |
 | Docker Desktop      | ✅             | —                             | —                                                                    |
 | Fantastical         | ✅             | —                             | [docs/apps/fantastical.md](docs/apps/fantastical.md)                 |
-| Figma               | ☐              | —                             | —                                                                    |
+| Figma               | ☐              | —                             | [docs/apps/figma.md](docs/apps/figma.md)                             |
 | Ghostty             | ☐              | `~/.config/ghostty`           | —                                                                    |
 | Google Chrome       | ☐              | —                             | [docs/apps/chrome.md](docs/apps/chrome.md)                           |
 | Google Japanese IME | ☐              | —                             | [docs/apps/google-japanese-ime.md](docs/apps/google-japanese-ime.md) |

--- a/docs/apps/figma.md
+++ b/docs/apps/figma.md
@@ -1,0 +1,3 @@
+# Figma
+
+- Click **Log in with browser** and sign in


### PR DESCRIPTION
## Why

Figma is installed as a cask, but the sign-in has to be done by hand after install, so `mise bootstrap` cannot reproduce it. Recording the step keeps it reproducible on a new machine, the same way as the other apps that need manual setup.

## What

- Add `docs/apps/figma.md` with the sign-in step
- Link it from the Setup section in `README.md`