### PR TITLE
feat(claude): set output style to Concise

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -69,6 +69,7 @@
     "defaultMode": "auto"
   },
   "model": "opus",
+  "outputStyle": "Concise",
   "hooks": {
     "PermissionRequest": [
       {


### PR DESCRIPTION
## Why

Claude Code's default responses include preamble and narration that are not needed for my workflow. The `Concise` output style keeps answers result-first and short without reducing thoroughness.

## What

- Add `outputStyle: "Concise"` to `home/.claude/settings.json`

## Notes

None.