### PR TITLE
chore(git): ignore `.claude/settings.local.json`

### DIFF
--- a/home/.config/git/ignore
+++ b/home/.config/git/ignore
@@ -9,3 +9,5 @@ Thumbs.db
 .playwright-mcp/
 .wt/
 mise.local.toml
+
+**/.claude/settings.local.json


### PR DESCRIPTION
## Why

`.claude/settings.local.json` holds machine-local Claude Code settings such as permission allowlists. It is specific to each machine and should not be committed to any repository, but it keeps showing up as an untracked file in every project.

## What

Add `**/.claude/settings.local.json` to the global gitignore.

## Notes

The `**/` prefix is required here. In gitignore, a pattern containing a slash anywhere but the end is anchored to the repository root, so `.claude/settings.local.json` alone would not match the file in subdirectories. The other entries in this file have no slash (or only a trailing one), so they already match at any depth without the prefix.