### PR TITLE
feat(claude): explain git add -A denial

### DIFF
--- a/home/.claude/hooks/block-git-add-all.sh
+++ b/home/.claude/hooks/block-git-add-all.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+cmd=$(jq -r '.tool_input.command // ""')
+
+if [[ $cmd =~ ^git[[:space:]]+add[[:space:]]+-A$ ]]; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "Do not use git add -A because it stages every change in the repository. Stage the intended paths explicitly with git add <path>."
+    }
+  }'
+fi

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -97,6 +97,10 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/block-git-c.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/block-git-add-all.sh"
           }
         ]
       }


### PR DESCRIPTION
## Why

A `git add -A` denial did not explain how to stage changes safely.

## What

- Add a `PreToolUse` hook that explains how to stage explicit paths.
- Register the hook for Bash tool calls.

## Notes

- The existing `Bash(git add -A)` deny rule remains as a safety control.