### PR TITLE
chore(git): ignore .pnpm-store directory

### DIFF
--- a/home/.config/git/ignore
+++ b/home/.config/git/ignore
@@ -7,6 +7,7 @@ Thumbs.db
 # Others
 .playwright-cli/
 .playwright-mcp/
+.pnpm-store/
 .wt/
 mise.local.toml
 


### PR DESCRIPTION
## Why

Prevent local pnpm store directories from being accidentally tracked.

## What

Add `.pnpm-store/` to the global Git ignore file.

## Notes

No tests run; configuration-only change.