### PR TITLE
chore(git): ignore `CLAUDE.local.md`

### DIFF
--- a/home/.config/git/ignore
+++ b/home/.config/git/ignore
@@ -11,3 +11,4 @@ Thumbs.db
 mise.local.toml
 
 **/.claude/settings.local.json
+CLAUDE.local.md


### PR DESCRIPTION
## Why

Claude Code loads `CLAUDE.local.md` as a `Local` scope memory file, which holds personal instructions that are not meant to be committed. Adding the same entry to every repository `.gitignore` is repetitive, and it also pushes a personal convention into shared repositories.

## What

Ignore `CLAUDE.local.md` in the global ignore file, alongside the existing `.claude/settings.local.json` entry.

## Notes

The pattern has no slash, so it matches in the repository root and in any subdirectory. If a repository ever needs to track the file, `git add -f` or a `!CLAUDE.local.md` entry in its `.gitignore` overrides this.
