### PR TITLE
feat(claude): work around rg permission prompt regression

### DIFF
--- a/home/.claude/rules/claude-code.md
+++ b/home/.claude/rules/claude-code.md
@@ -1,3 +1,5 @@
 # Claude Code
 
 - ユーザーに質問するときは、積極的に `AskUserQuestion` ツールを使います
+- `rg` には検索対象のファイルやディレクトリを明示し、パス無しや `.` でカレントディレクトリ全体を検索しません。パイプの後ろで標準入力をフィルタするときは `rg` ではなく `grep` を使います
+  - Claude Code 2.1.259 で、パス無しの `rg` がカレントディレクトリ全体の検索と判定され、`Read()` の deny ルールに触れて確認プロンプトが出るリグレッションの回避策です（[anthropics/claude-code#91751](https://github.com/anthropics/claude-code/issues/91751)）。修正されたらこの項目は削除します


### PR DESCRIPTION
## Why

Since Claude Code 2.1.259, a path-less `rg` (including `cmd | rg pattern` and `rg pattern .`) is modelled by the Bash permission checker as a search of the whole cwd. When a `Read()` deny rule covers a file under the cwd (e.g. `.env` with `Read(.env*)`), this escalates to a confirmation prompt with `classifier_approvable: false`, so auto mode cannot approve it and nearly every filter pipeline stops for a human click. Upstream: [anthropics/claude-code#91751](https://github.com/anthropics/claude-code/issues/91751).

## What

Add a temporary rule to `home/.claude/rules/claude-code.md`:

- Always pass an explicit file or directory to `rg`; do not search the whole cwd with no path or `.`.
- Use `grep` instead of `rg` when filtering stdin after a pipe.

The rule links the upstream issue and says it should be removed once the regression is fixed.

## Notes

Verified headless on 2.1.259 (`--permission-prompt-tool stdio`, `--permission-mode default`) in a cwd containing `.env`, with the current `Read(.env*)` deny rule:

| Command | Result |
| :-- | :-- |
| `printf 'a\nb\n' \| rg a` | prompts |
| `printf 'a\nb\n' \| rg a -` | prompts (so [#594](https://github.com/p-chan/dotfiles/pull/594) was closed) |
| `printf 'a\nb\n' \| grep a` | runs |
| `rg -uuu -n ok sub/` | runs |

`block-grep.sh` only blocks commands that start with `grep` (`^grep\b`), so `grep` in the pipe position already passes the hook and no hook change is needed.
